### PR TITLE
profile view visibility

### DIFF
--- a/server/src/main/java/edu/sjsu/moth/server/controller/StatusController.java
+++ b/server/src/main/java/edu/sjsu/moth/server/controller/StatusController.java
@@ -177,7 +177,7 @@ public class StatusController {
 
     // spec: https://docs.joinmastodon.org/methods/accounts/#statuses
     @GetMapping("/api/v1/accounts/{id}/statuses")
-    Mono<ResponseEntity<List<Status>>> getApiV1AccountsStatuses(@PathVariable String id,
+    Mono<ResponseEntity<List<Status>>> getApiV1AccountsStatuses(Principal user, @PathVariable String id,
             /* String. Return results older than this ID */ String max_id,
             /* String. Return results newer than this ID */ String since_id,
             /* String. Return results immediately newer than this ID */ String min_id,
@@ -189,7 +189,7 @@ public class StatusController {
             statuses do not receive special priority in the order of the returned results. */ Boolean pinned,
             /* String. Filter for statuses using a specific hashtag */ String tagged) {
         return accountService.getAccountById(id).flatMap(
-                        acct -> statusService.getStatusesForId(acct.username, max_id, since_id, min_id, only_media,
+                        acct -> statusService.getStatusesForId(user, acct.username, max_id, since_id, min_id, only_media,
                                                                exclude_replies, exclude_reblogs, pinned, tagged, limit))
                 .map(ResponseEntity::ok);
     }


### PR DESCRIPTION
- This PR implement profile view visiblity for Moth. The profile view feature will return all of the status with PUBLIC or QUIET_PUBLIC level. If user view profile of the following user, the FOLLOW level status is displayed also. The mentioned status can only be seen by people mentioned in the status.
- [x] Implement profile view visibility
- [x] Integration test for profile view visibility
