### PR TITLE
Adding support for HTTP signature verification, caching the public key , and ActivityPub integration

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -117,6 +117,12 @@
             <artifactId>querydsl-apt</artifactId>
             <version>5.0.0</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+            <version>3.1.8</version>
+        </dependency>
     </dependencies>
     <build>
         <finalName>moth-server</finalName>

--- a/server/src/main/java/edu/sjsu/moth/server/filter/HttpSignatureWebFilter.java
+++ b/server/src/main/java/edu/sjsu/moth/server/filter/HttpSignatureWebFilter.java
@@ -1,0 +1,85 @@
+package edu.sjsu.moth.server.filter;
+
+import edu.sjsu.moth.server.service.HttpSignatureService;
+import lombok.NonNull;
+import lombok.extern.apachecommons.CommonsLog;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DataBufferUtils;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.server.PathContainer;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.http.server.reactive.ServerHttpRequestDecorator;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+import org.springframework.web.util.pattern.PathPattern;
+import org.springframework.web.util.pattern.PathPatternParser;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.Arrays;
+import java.util.List;
+
+@CommonsLog
+public class HttpSignatureWebFilter implements WebFilter {
+
+    private final HttpSignatureService httpSignatureService;
+    private final List<PathPattern> protectedPatterns;
+
+    public HttpSignatureWebFilter(HttpSignatureService httpSignatureService) {
+        this.httpSignatureService = httpSignatureService;
+        PathPatternParser parser = new PathPatternParser();
+        this.protectedPatterns = List.of(parser.parse("/inbox"), parser.parse("/users/{id}/inbox"));
+    }
+
+    @Override
+    @NonNull
+    public Mono<Void> filter(@NonNull ServerWebExchange exchange, @NonNull WebFilterChain chain) {
+
+        ServerHttpRequest request = exchange.getRequest();
+        PathContainer requestPath = request.getPath().pathWithinApplication();
+        HttpMethod requestMethod = request.getMethod();
+
+        boolean protectedPost =
+                requestMethod == HttpMethod.POST && protectedPatterns.stream().anyMatch(p -> p.matches(requestPath));
+        if (!protectedPost) {
+            return chain.filter(exchange);
+        }
+
+        boolean hasSignature = request.getHeaders().containsKey("Signature");
+        if (!hasSignature) {
+            log.warn("Missing Signature on protected POST " + requestPath.value());
+            exchange.getResponse().setStatusCode(HttpStatus.UNAUTHORIZED);
+            return exchange.getResponse().setComplete();
+        }
+
+        log.info("Attempting signature verification for: " + requestMethod + " " + requestPath);
+        return DataBufferUtils.join(exchange.getRequest().getBody()).flatMap(buf -> {
+            byte[] bytes = new byte[buf.readableByteCount()];
+            buf.read(bytes);
+            DataBufferUtils.release(buf);
+
+            System.out.println(Arrays.toString(bytes));
+
+            Flux<DataBuffer> replay = Flux.defer(() -> Mono.just(exchange.getResponse().bufferFactory().wrap(bytes)));
+            ServerHttpRequest decorated = new ServerHttpRequestDecorator(exchange.getRequest()) {
+                @Override
+                public @NotNull Flux<DataBuffer> getBody() {return replay;}
+            };
+            ServerWebExchange mutated = exchange.mutate().request(decorated).build();
+
+            return httpSignatureService.verifySignature(mutated, bytes).flatMap(isValid -> {
+                if (isValid) {
+                    log.debug("HTTP Signature verified successfully for " + requestMethod + " " + requestPath.value());
+                    return chain.filter(mutated);
+                } else {
+                    log.warn("HTTP Signature verification failed for : " + requestMethod + " " + requestPath.value());
+                    mutated.getResponse().setStatusCode(HttpStatus.UNAUTHORIZED);
+                    return mutated.getResponse().setComplete();
+                }
+            });
+        });
+    }
+}

--- a/server/src/main/java/edu/sjsu/moth/server/security/PublicKeyResolver.java
+++ b/server/src/main/java/edu/sjsu/moth/server/security/PublicKeyResolver.java
@@ -1,0 +1,9 @@
+package edu.sjsu.moth.server.security;
+
+import reactor.core.publisher.Mono;
+
+import java.security.PublicKey;
+
+public interface PublicKeyResolver {
+    Mono<PublicKey> resolve(String keyId);
+}

--- a/server/src/main/java/edu/sjsu/moth/server/security/RemotePublicKeyResolver.java
+++ b/server/src/main/java/edu/sjsu/moth/server/security/RemotePublicKeyResolver.java
@@ -1,0 +1,97 @@
+package edu.sjsu.moth.server.security;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.github.benmanes.caffeine.cache.AsyncCache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import edu.sjsu.moth.util.HttpSignature;
+import lombok.extern.apachecommons.CommonsLog;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+import java.security.PublicKey;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+
+//Why? to make HttpSignatureService.verifySignature() becomes a short chain of pure operators;
+@Service
+@CommonsLog
+public class RemotePublicKeyResolver implements PublicKeyResolver {
+
+    public static final Object NEGATIVE_CACHE_SENTINEL = new Object();
+    public final AsyncCache<String, PublicKey> publicKeyCache;
+    public final AsyncCache<String, Object> negativeLookupCache;
+    private final WebClient webClient;
+
+    // https://www.w3.org/TR/activitypub/#retrieving-objects
+    @Autowired
+    public RemotePublicKeyResolver(WebClient.Builder webClientBuilder) {
+        this.webClient = webClientBuilder.defaultHeader(HttpHeaders.ACCEPT,
+                                                        "application/activity+json, application/activity+json, " +
+                                                                "application/ld+json", MediaType.APPLICATION_JSON_VALUE)
+                .build();
+
+        // expires after a year?
+        this.publicKeyCache =
+                Caffeine.newBuilder().maximumSize(10_000).expireAfterWrite(Duration.ofDays(365)).buildAsync();
+
+        this.negativeLookupCache = Caffeine.newBuilder().maximumSize(10_000) // limits the retry count
+                .expireAfterWrite(Duration.ofMinutes(10)).buildAsync();
+    }
+
+    // https://socialhub.activitypub.rocks/t/verifying-deletes-of-users-who-are-gone/240/1
+    // For deleted users: verify only if their key is in cache, otherwise ignore it
+    @Override
+    public Mono<PublicKey> resolve(String keyId) {
+        // check the positive cache first, if found happy!
+        CompletableFuture<PublicKey> cachedKey = publicKeyCache.getIfPresent(keyId);
+        if (cachedKey != null) {
+            return Mono.fromFuture(cachedKey).subscribeOn(Schedulers.boundedElastic());
+        }
+
+        // check negative cache if not in positive cache
+        CompletableFuture<Object> negativelyCached = negativeLookupCache.getIfPresent(keyId);
+        if (negativelyCached != null) {
+            return Mono.fromFuture(negativelyCached).subscribeOn(Schedulers.boundedElastic())
+                    .flatMap(v -> Mono.empty()); // Indicates a known miss
+        }
+
+        // https://socialhub.activitypub.rocks/t/authorized-fetch-and-the-instance-actor/3868
+        // TODO : use activity pub service to fetch the actor, Authorise fetch?
+
+        String actorUrl = keyId.split("#")[0];
+        return this.webClient.get().uri(actorUrl).retrieve().bodyToMono(JsonNode.class)
+                .subscribeOn(Schedulers.boundedElastic()) // Perform network I/O on boundedElastic
+                .flatMap(actorNode -> {
+                    JsonNode publicKeyNode = actorNode.path("publicKey").path("publicKeyPem");
+                    if (publicKeyNode.isMissingNode() || publicKeyNode.isNull() || !publicKeyNode.isTextual()) {
+                        log.warn("publicKeyPem not found or not a string for keyId: " + keyId);
+                        return Mono.empty();
+                    }
+                    String pem = publicKeyNode.asText();
+                    try {
+                        PublicKey publicKey = HttpSignature.pemToPublicKey(pem);
+                        return Mono.justOrEmpty(publicKey);
+                    } catch (Exception e) {
+                        log.error("Failed to convert PEM to PublicKey for keyId: " + keyId, e);
+                        return Mono.empty();
+                    }
+                }).doOnSuccess(publicKey -> {
+                    if (publicKey != null) {
+                        publicKeyCache.put(keyId, CompletableFuture.completedFuture(publicKey));
+                        log.debug("Cached public key for: " + keyId);
+                    } else {
+                        negativeLookupCache.put(keyId, CompletableFuture.completedFuture(NEGATIVE_CACHE_SENTINEL));
+                        log.debug("Cached negative lookup for: " + keyId);
+                    }
+                }).doOnError(error -> {
+                    negativeLookupCache.put(keyId, CompletableFuture.completedFuture(NEGATIVE_CACHE_SENTINEL));
+                    log.warn("Error fetching public key for keyId " + keyId + ", caching negative lookup.", error);
+                }).onErrorResume(e -> Mono.empty());
+
+    }
+}

--- a/server/src/main/java/edu/sjsu/moth/server/service/AccountService.java
+++ b/server/src/main/java/edu/sjsu/moth/server/service/AccountService.java
@@ -32,7 +32,6 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import static edu.sjsu.moth.server.util.Util.signAndSend;
 import static org.springframework.beans.support.PagedListHolder.DEFAULT_PAGE_SIZE;
 
 /**
@@ -61,7 +60,7 @@ public class AccountService {
     private ObjectMapper objectMapper;
 
     @Autowired
-    private HttpSignatureService httpSignatureService;
+    private ActivityPubService activityPubService;
 
     static PubKeyPair genPubKeyPair(String acct) {
         var pair = WebFingerUtils.genPubPrivKeyPem();
@@ -179,8 +178,7 @@ public class AccountService {
         String actorUrl = String.format("https://%s/users/%s", mydomain, id);
         AcceptMessage acceptMessage = new AcceptMessage(messageId, actorUrl, body);
         JsonNode message = objectMapper.valueToTree(acceptMessage);
-        return getPrivateKey(id, true)
-                .flatMap(privKey -> signAndSend(message, actorUrl,followerDomain,message.get("object").get("actor").asText() + "/inbox",privKey));
+        return activityPubService.sendSignedActivity(message, id, body.get("actor").asText() + "/inbox");
     }
 
     public Mono<ArrayList<Account>> userFollowInfo(String id, String max_id, String since_id, String min_id,

--- a/server/src/main/java/edu/sjsu/moth/server/service/ActivityPubService.java
+++ b/server/src/main/java/edu/sjsu/moth/server/service/ActivityPubService.java
@@ -1,0 +1,73 @@
+package edu.sjsu.moth.server.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.apachecommons.CommonsLog;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.net.URI;
+
+// orchestrating the sending of signed ActivityPub activities.
+@Service
+@CommonsLog
+public class ActivityPubService {
+
+    private final HttpSignatureService httpSignatureService;
+
+    public ActivityPubService(HttpSignatureService httpSignatureService) {
+        this.httpSignatureService = httpSignatureService;
+    }
+
+    public Mono<Void> sendSignedActivity(JsonNode message, String sendingActorId, String targetInbox) {
+        URI targetUri;
+        try {
+            targetUri = URI.create(targetInbox);
+            if (targetUri.getHost() == null) {
+                throw new IllegalArgumentException("Target inbox URI missing host");
+            }
+        } catch (Exception e) {
+            log.error("Invalid target inbox URI: " + targetInbox, e);
+            return Mono.error(new IllegalArgumentException("Invalid target inbox URI: " + targetInbox, e));
+        }
+        final URI finalTargetUri = targetUri;
+
+        byte[] bodyBytes;
+        try {
+            bodyBytes = new ObjectMapper().writeValueAsBytes(message);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+
+        return httpSignatureService.prepareSignedHeaders(HttpMethod.POST, sendingActorId, finalTargetUri, bodyBytes)
+                .flatMap(headers -> {
+                    WebClient client =
+                            WebClient.builder().defaultHeaders(httpHeaders -> httpHeaders.addAll(headers)).build();
+                    log.info("Sending signed activity from " + sendingActorId + " to " + targetInbox);
+                    return client.post().uri(targetUri).contentType(MediaType.APPLICATION_JSON).bodyValue(message)
+                            .retrieve().onStatus(HttpStatusCode::is4xxClientError,
+                                                 res -> res.bodyToMono(String.class).flatMap(body -> {
+                                                     System.err.println(
+                                                             "4xx error sending activity to " + targetInbox + ": " +
+                                                                     body);
+                                                     return Mono.error(new RuntimeException("Client error: " + body));
+                                                 })).onStatus(HttpStatusCode::is5xxServerError,
+                                                              res -> res.bodyToMono(String.class).flatMap(body -> {
+                                                                  System.err.println("5xx error sending activity to " +
+                                                                                             targetInbox + ": " + body);
+                                                                  return Mono.error(new RuntimeException(
+                                                                          "Server error: " + body));
+                                                              })).bodyToMono(String.class)
+                            .doOnSuccess(response -> log.info("Successfully sent activity to " + targetInbox)).then();
+                }).onErrorResume(e -> {
+                    log.error("Failed pipeline before/during sending signed activity to " + targetInbox + ": " +
+                                      e.getMessage(), e);
+                    return Mono.error(e);
+                });
+    }
+}

--- a/server/src/main/java/edu/sjsu/moth/server/service/HttpSignatureService.java
+++ b/server/src/main/java/edu/sjsu/moth/server/service/HttpSignatureService.java
@@ -34,6 +34,8 @@ import java.util.Objects;
 public class HttpSignatureService {
     private static final int TIMESTAMP_TOLERANCE_SECONDS = 12 * 60 * 60; // TODO : should be configurable
     private static final int SHA256_DIGEST_LENGTH_BYTES = 32;
+    private static final DateTimeFormatter RFC_1123_COMPLIANT_FORMATTER =
+            DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss 'GMT'", Locale.US).withZone(ZoneOffset.UTC);
     private final PubKeyPairRepository pubKeyPairRepository;
     private final WebClient webClient;
     private final String serverName;
@@ -50,9 +52,7 @@ public class HttpSignatureService {
     // https://stackoverflow.com/questions/45829799/java-time-format-datetimeformatter-rfc-1123-date-time-fails-to-parse-time-zone-n
     // RFC 1123 = HTTP Date Format (https://github.com/mastodon/mastodon/blob/main/app/lib/request.rb)
     public static String formatHttpDate(ZonedDateTime dateTime) {
-        return DateTimeFormatter.RFC_1123_DATE_TIME.format(dateTime);
-        // TODO : lookup for the edge cases (https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html)
-        // TODO : move to HttpSignature class?
+        return RFC_1123_COMPLIANT_FORMATTER.format(dateTime);
     }
 
     public Mono<ClientRequest> signRequest(ClientRequest request, String accountId, @Nullable byte[] body) {

--- a/server/src/main/java/edu/sjsu/moth/server/service/HttpSignatureService.java
+++ b/server/src/main/java/edu/sjsu/moth/server/service/HttpSignatureService.java
@@ -1,23 +1,21 @@
 package edu.sjsu.moth.server.service;
 
 import edu.sjsu.moth.server.db.PubKeyPairRepository;
+import edu.sjsu.moth.server.security.PublicKeyResolver;
 import edu.sjsu.moth.server.util.MothConfiguration;
 import edu.sjsu.moth.util.HttpSignature;
 import lombok.extern.apachecommons.CommonsLog;
-import org.springframework.core.io.buffer.DataBufferUtils;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
-import org.springframework.web.reactive.function.client.ClientRequest;
-import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 
+import java.net.URI;
 import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
-import java.security.PublicKey;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -26,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 
@@ -37,14 +36,14 @@ public class HttpSignatureService {
     private static final DateTimeFormatter RFC_1123_COMPLIANT_FORMATTER =
             DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss 'GMT'", Locale.US).withZone(ZoneOffset.UTC);
     private final PubKeyPairRepository pubKeyPairRepository;
-    private final WebClient webClient;
     private final String serverName;
     // https://docs.joinmastodon.org/spec/security/
-    private final List<String> headersToSign = List.of(HttpSignature.REQUEST_TARGET, "host", "date");
+    private final List<String> baseHeadersToSign = List.of(HttpSignature.REQUEST_TARGET, "host", "date");
+    private final PublicKeyResolver keyResolver;
 
-    public HttpSignatureService(PubKeyPairRepository pubKeyPairRepository, WebClient.Builder webClientBuilder) {
+    public HttpSignatureService(PubKeyPairRepository pubKeyPairRepository, PublicKeyResolver keyResolver) {
         this.pubKeyPairRepository = pubKeyPairRepository;
-        this.webClient = webClientBuilder.defaultHeader(HttpHeaders.ACCEPT, "application/activity+json").build();
+        this.keyResolver = keyResolver;
         this.serverName = MothConfiguration.mothConfiguration.getServerName();
     }
 
@@ -60,7 +59,7 @@ public class HttpSignatureService {
         return pubKeyPairRepository.findItemByAcct(sendingActorId).switchIfEmpty(
                         Mono.error(() -> new RuntimeException("Private key not found for actor: " + sendingActorId)))
                 .handle((keyPair, sink) -> {
-            try {
+                    try {
                         PrivateKey privateKey = HttpSignature.pemToPrivateKey(keyPair.privateKeyPEM);
                         String keyId = "https://" + serverName + "/users/" + sendingActorId + "#main-key";
                         String targetHost = targetUri.getHost();
@@ -80,29 +79,28 @@ public class HttpSignatureService {
                             headers.setContentType(MediaType.valueOf(
                                     "application/ld+json; profile=\"https://www.w3.org/ns/activitystreams\""));
                             HttpSignature.addDigest(headers, bodyBytes != null ? bodyBytes : new byte[0]);
-                    headersToSign.add("digest");
-                }
+                            headersToSign.add("digest");
+                        }
                         String signatureHeaderValue =
                                 HttpSignature.generateSignatureHeader(method.name(), targetUri, headers, headersToSign,
                                                                       privateKey, keyId);
                         headers.set("Signature", signatureHeaderValue);
                         sink.next(headers);
-            } catch (Exception e) {
+                    } catch (Exception e) {
                         sink.error(new RuntimeException("Failed to prepare signed headers", e));
-            }
+                    }
                 });
     }
 
     // https://github.com/mastodon/mastodon/blob/ff7230df065461ad3fafefdb974f723641059388/app/controllers/concerns/signature_verification.rb
-    public Mono<Boolean> verifySignature(ServerWebExchange exchange) {
-        // TODO : Caching, Domain Blocking, Local URI Checks, Rate Limiting, retry if key fetching fails.
+    public Mono<Boolean> verifySignature(ServerWebExchange exchange, byte[] bodyBytes) {
+        // TODO : Domain Blocking, Local URI Checks
         HttpHeaders headers = exchange.getRequest().getHeaders();
         String signatureHeader = headers.getFirst("Signature");
 
         if (signatureHeader == null) {
             log.warn("No Signature header in request to " + exchange.getRequest().getPath());
             return Mono.just(false);
-            // TODO : more error handling?
         }
 
         Map<String, String> fields = HttpSignature.extractFields(signatureHeader);
@@ -172,12 +170,7 @@ public class HttpSignatureService {
         Mono<Boolean> digestCheckResult;
         if (headersToVerifyList.contains("digest")) {
             String digestHeaderValue = headers.getFirst("Digest");
-            if (digestHeaderValue == null || digestHeaderValue.isBlank()) {
-                log.warn("Digest header signed but missing/empty in request.");
-                digestCheckResult = Mono.just(false);
-            } else {
-                digestCheckResult = checkRequestDigest(exchange, headers);
-            }
+            digestCheckResult = checkRequestDigest(digestHeaderValue, bodyBytes);
         } else {
             digestCheckResult = Mono.just(true);
         }
@@ -185,14 +178,14 @@ public class HttpSignatureService {
         return digestCheckResult.filter(Boolean::booleanValue).switchIfEmpty(Mono.defer(() -> {
                     log.warn("Digest verification failed or header mismatch.");
                     return Mono.just(false);
-                })).flatMap(ignored -> fetchPublicKey(keyId)) // digest verified, good to go for the signature
+                })).flatMap(ignored -> keyResolver.resolve(keyId)) // digest verified, good to go for the signature
                 .flatMap(publicKey -> {
                     try {
+                        log.info("Validating signature for keyId: " + keyId);
                         boolean isValid =
                                 HttpSignature.validateSignatureHeader(exchange.getRequest().getMethod().name(),
                                                                       exchange.getRequest().getURI(), headers,
                                                                       headersToVerify, publicKey, signature);
-
                         if (!isValid) {
                             log.warn("Invalid signature value for request from keyId: " + keyId);
                         }
@@ -204,9 +197,7 @@ public class HttpSignatureService {
                 }).defaultIfEmpty(false);
     }
 
-    private Mono<Boolean> checkRequestDigest(ServerWebExchange exchange, HttpHeaders headers) {
-        // ONLY "SHA-256=value", might need to add
-        String digestHeaderValue = headers.getFirst("Digest");
+    private Mono<Boolean> checkRequestDigest(String digestHeaderValue, @Nullable byte[] bytes) {
         String expectedValueBase64;
         if (digestHeaderValue == null) return Mono.just(false);
         String[] parts = digestHeaderValue.trim().split("=", 2); // Split into max 2 parts
@@ -233,71 +224,29 @@ public class HttpSignatureService {
             return Mono.just(false);
         }
 
-        final String finalExpectedValueBase64 = expectedValueBase64;
-
-        // calculate the actual digest
-        return DataBufferUtils.join(exchange.getRequest().getBody()).map(dataBuffer -> {
-            byte[] bodyBytes = new byte[dataBuffer.readableByteCount()];
-            dataBuffer.read(bodyBytes);
-            DataBufferUtils.release(dataBuffer);
-            return bodyBytes;
-        }).defaultIfEmpty(new byte[0]).<Boolean>handle((bodyBytes, sink) -> {
+        try {
             MessageDigest sha256 = HttpSignature.newSHA256Digest();
             if (sha256 == null) {
-                sink.error(new NoSuchAlgorithmException("SHA-256 MessageDigest unavailable"));
-                return;
+                log.error("SHA-256 MessageDigest algorithm not available.");
+                return Mono.just(false);
             }
 
-            byte[] actualDigestBytes = sha256.digest(bodyBytes);
-            String actualDigestBase64 = Base64.getEncoder().encodeToString(actualDigestBytes);
+            byte[] bodyToDigest = (bytes != null) ? bytes : new byte[0];
+            byte[] actualDigestBytes = sha256.digest(bodyToDigest);
 
-            // 7. Compare
-            boolean match = Objects.equals(actualDigestBase64, finalExpectedValueBase64);
+            String actualDigestBase64 = Base64.getEncoder().encodeToString(actualDigestBytes);
+            boolean match = Objects.equals(actualDigestBase64, expectedValueBase64);
             if (!match) {
-                log.warn("Digest mismatch. Header: SHA-256=" + finalExpectedValueBase64 + ", Calculated: SHA-256=" +
+                log.warn("Digest mismatch. Header: SHA-256=" + expectedValueBase64 + ", Calculated: SHA-256=" +
                                  actualDigestBase64);
             } else {
                 log.trace("Digest matched.");
             }
-            sink.next(match);
-        }).onErrorResume(e -> {
+            return Mono.just(match);
+        } catch (Exception e) {
             log.error("Error calculating request body digest", e);
             return Mono.just(false);
-        });
-    }
-
-    public Mono<PublicKey> fetchPublicKey(String keyId) {
-        // mastodon has separate remote key fetching service (https://github.com/mastodon/mastodon/blob/ff7230df065461ad3fafefdb974f723641059388/app/services/activitypub/fetch_remote_key_service.rb)
-        // TODO : Check cache first
-        // TODO : check if its local users? optimisation
-
-        // Fetch if not local (keyId -> actor > publicKey > publicKeyPem)
-        String actorUrl = keyId.split("#")[0];
-        return webClient.get().uri(actorUrl).retrieve().bodyToMono(Map.class).flatMap(actor -> {
-            try {
-                Map<String, Object> publicKeyObject = (Map<String, Object>) actor.get("publicKey");
-                if (publicKeyObject == null) {
-                    log.warn("No publicKey in actor document: " + actorUrl);
-                    return Mono.empty();
-                }
-
-                String publicKeyPem = (String) publicKeyObject.get("publicKeyPem");
-                if (publicKeyPem == null) {
-                    log.warn("No publicKeyPem in actor document: " + actorUrl);
-                    return Mono.empty();
-                }
-                PublicKey publicKey = HttpSignature.pemToPublicKey(publicKeyPem);
-
-                if (publicKey == null) return Mono.empty();
-                return Mono.just(publicKey);
-            } catch (Exception e) {
-                log.error("Error extracting public key from actor", e);
-                return Mono.empty();
-            }
-        }).onErrorResume(e -> {
-            log.error("Error fetching actor document: " + actorUrl, e);
-            return Mono.empty();
-        });
+        }
     }
 
     private boolean isDateValid(String dateHeader) {

--- a/server/src/main/java/edu/sjsu/moth/server/util/Util.java
+++ b/server/src/main/java/edu/sjsu/moth/server/util/Util.java
@@ -1,13 +1,7 @@
 package edu.sjsu.moth.server.util;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.sjsu.moth.util.EmailCodeUtils;
-import edu.sjsu.moth.util.HttpSignature;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatusCode;
-import org.springframework.http.MediaType;
-import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
 import java.lang.ref.WeakReference;
@@ -15,18 +9,9 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
-import java.security.KeyFactory;
-import java.security.MessageDigest;
-import java.security.PrivateKey;
-import java.security.Signature;
-import java.security.spec.PKCS8EncodedKeySpec;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.Base64;
 import java.util.Enumeration;
 import java.util.List;
-import java.util.Locale;
 import java.util.Random;
 import java.util.Spliterator;
 import java.util.Spliterators;
@@ -107,68 +92,6 @@ public class Util {
             } else {
                 System.out.println(indent + value);
             }
-        }
-    }
-
-    public static Mono<Void> signAndSend(JsonNode message, String actorUrl, String targetDomain, String inbox, String privateKeyPEM) {
-        try {
-            // Construct actor and inbox info
-            URI inboxUri = URI.create(inbox);
-            PrivateKey signingKey = HttpSignature.pemToPrivateKey(privateKeyPEM);
-
-            // Prepare request body and compute digest
-            byte[] bodyBytes = new ObjectMapper().writeValueAsBytes(message);
-
-            // Prepare date string in HTTP format
-            String date = DateTimeFormatter.RFC_1123_DATE_TIME
-                    .format(ZonedDateTime.now(ZoneId.of("GMT")));
-
-            // Set initial headers
-            HttpHeaders headers = new HttpHeaders();
-            headers.add("Host", targetDomain);
-            headers.add("Date", date);
-            HttpSignature.addDigest(headers, bodyBytes); // adds SHA-256 digest header
-
-            // Headers to be signed
-            List<String> signedHeaders = List.of(
-                    HttpSignature.REQUEST_TARGET, "host", "date", "digest"
-            );
-
-            // Create WebClient builder
-            WebClient.Builder builder = WebClient.builder()
-                    .defaultHeader(HttpHeaders.ACCEPT, "application/activity+json")
-                    .defaultHeader("Host", targetDomain)
-                    .defaultHeader("Date", date)
-                    .defaultHeader("Digest", headers.getFirst("Digest"));
-
-            // Attach HTTP Signature filter
-            HttpSignature.signHeaders(builder, signedHeaders, signingKey, actorUrl + "#main-key");
-
-            WebClient client = builder.build();
-
-            // Send the signed POST request
-            return client.post()
-                    .uri(inboxUri)
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .bodyValue(message)
-                    .retrieve()
-                    .onStatus(HttpStatusCode::is4xxClientError, res ->
-                            res.bodyToMono(String.class).flatMap(body -> {
-                                System.err.println("4xx error body: " + body);
-                                return Mono.error(new RuntimeException("Client error: " + body));
-                            }))
-                    .onStatus(HttpStatusCode::is5xxServerError, res ->
-                            res.bodyToMono(String.class).flatMap(body -> {
-                                System.err.println("5xx error body: " + body);
-                                return Mono.error(new RuntimeException("Server error: " + body));
-                            }))
-                    .bodyToMono(String.class)
-                    .doOnNext(response -> System.out.println("Response: " + response))
-                    .then();
-
-        } catch (Exception e) {
-            System.err.println("Error during signAndSend: " + e.getMessage());
-            return Mono.error(new RuntimeException("Signing failed", e));
         }
     }
 

--- a/server/src/test/java/edu/sjsu/moth/controllers/InstanceControllerTest.java
+++ b/server/src/test/java/edu/sjsu/moth/controllers/InstanceControllerTest.java
@@ -4,6 +4,7 @@ import edu.sjsu.moth.server.controller.InstanceController;
 import edu.sjsu.moth.server.db.AccountRepository;
 import edu.sjsu.moth.server.db.TokenRepository;
 import edu.sjsu.moth.server.service.AccountService;
+import edu.sjsu.moth.server.service.HttpSignatureService;
 import edu.sjsu.moth.server.util.ContentSecurityPolicyConfiguration;
 import edu.sjsu.moth.util.MothTestInitializer;
 import org.junit.jupiter.api.Test;
@@ -30,6 +31,9 @@ public class InstanceControllerTest {
 
     @MockBean
     AccountRepository accountRepository;
+
+    @MockBean
+    HttpSignatureService httpSignatureService;
 
     @Autowired
     private WebTestClient webTestClient;

--- a/server/src/test/java/edu/sjsu/moth/filter/HttpSignatureWebFilterTest.java
+++ b/server/src/test/java/edu/sjsu/moth/filter/HttpSignatureWebFilterTest.java
@@ -1,0 +1,215 @@
+package edu.sjsu.moth.filter;
+
+import edu.sjsu.moth.server.filter.HttpSignatureWebFilter;
+import edu.sjsu.moth.server.service.HttpSignatureService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.io.buffer.DataBufferFactory;
+import org.springframework.core.io.buffer.DataBufferUtils;
+import org.springframework.core.io.buffer.DefaultDataBufferFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.server.reactive.ServerHttpRequestDecorator;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class HttpSignatureWebFilterTest {
+
+    private final DataBufferFactory dataBufferFactory = new DefaultDataBufferFactory();
+    @Mock
+    private HttpSignatureService mockHttpSignatureService;
+    @Mock
+    private WebFilterChain mockWebFilterChain;
+    @Captor
+    private ArgumentCaptor<ServerWebExchange> exchangeCaptor;
+    @Captor
+    private ArgumentCaptor<byte[]> bodyBytesCaptor;
+    private HttpSignatureWebFilter httpSignatureWebFilter;
+
+    @BeforeEach
+    void setUp() {
+        httpSignatureWebFilter = new HttpSignatureWebFilter(mockHttpSignatureService);
+        lenient().when(mockWebFilterChain.filter(any(ServerWebExchange.class))).thenReturn(Mono.empty());
+    }
+
+    private MockServerWebExchange createExchange(HttpMethod method, String path, HttpHeaders headers, byte[] body) {
+        MockServerHttpRequest.BodyBuilder requestBuilder = MockServerHttpRequest.method(method, path).headers(headers);
+        MockServerHttpRequest request =
+                body != null ? requestBuilder.body(Flux.just(dataBufferFactory.wrap(body))) : requestBuilder.build();
+        return MockServerWebExchange.from(request);
+    }
+
+    @Test
+    void filterGetRequestShouldPassThrough() {
+        HttpHeaders headers = new HttpHeaders();
+        MockServerWebExchange exchange = createExchange(HttpMethod.GET, "/inbox", headers, null);
+
+        StepVerifier.create(httpSignatureWebFilter.filter(exchange, mockWebFilterChain)).verifyComplete();
+
+        verify(mockWebFilterChain).filter(exchange); // Original exchange should be passed
+        verify(mockHttpSignatureService, never()).verifySignature(any(), any());
+    }
+
+    @Test
+    void filterPostToNonProtectedPathShouldPassThrough() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Signature", "some-signature"); // Even if signature is present
+        MockServerWebExchange exchange =
+                createExchange(HttpMethod.POST, "/some/other/path", headers, "body".getBytes());
+
+        StepVerifier.create(httpSignatureWebFilter.filter(exchange, mockWebFilterChain)).verifyComplete();
+
+        verify(mockWebFilterChain).filter(exchange);
+        verify(mockHttpSignatureService, never()).verifySignature(any(), any());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "/inbox", "/users/testUser/inbox" })
+    void filter_postToProtectedPath_missingSignatureHeader_shouldReturnUnauthorized(String protectedPath) {
+        HttpHeaders headers = new HttpHeaders();
+        MockServerWebExchange exchange = createExchange(HttpMethod.POST, protectedPath, headers, "body".getBytes());
+
+        StepVerifier.create(httpSignatureWebFilter.filter(exchange, mockWebFilterChain)).verifyComplete();
+
+        assertEquals(HttpStatus.UNAUTHORIZED, exchange.getResponse().getStatusCode());
+        verify(mockWebFilterChain, never()).filter(any());
+        verify(mockHttpSignatureService, never()).verifySignature(any(), any());
+    }
+
+    private void testSuccessfulSignatureVerification(String protectedPath, byte[] requestBody) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Signature", "valid-signature");
+        MockServerWebExchange exchange = createExchange(HttpMethod.POST, protectedPath, headers, requestBody);
+
+        when(mockHttpSignatureService.verifySignature(any(ServerWebExchange.class), eq(requestBody))).thenReturn(
+                Mono.just(true));
+
+        StepVerifier.create(httpSignatureWebFilter.filter(exchange, mockWebFilterChain)).verifyComplete();
+
+        verify(mockHttpSignatureService).verifySignature(exchangeCaptor.capture(), bodyBytesCaptor.capture());
+        assertArrayEquals(requestBody, bodyBytesCaptor.getValue());
+
+        ServerWebExchange capturedExchange = exchangeCaptor.getValue();
+        assertNotNull(capturedExchange);
+        assertTrue(capturedExchange.getRequest() instanceof ServerHttpRequestDecorator, "Request should be decorated");
+
+        // verify that the captured exchange has a replayable body
+        Mono<byte[]> firstRead = DataBufferUtils.join(capturedExchange.getRequest().getBody()).map(dataBuffer -> {
+            byte[] bytes = new byte[dataBuffer.readableByteCount()];
+            dataBuffer.read(bytes);
+            DataBufferUtils.release(dataBuffer);
+            return bytes;
+        });
+        Mono<byte[]> secondRead = DataBufferUtils.join(capturedExchange.getRequest().getBody()).map(dataBuffer -> {
+            byte[] bytes = new byte[dataBuffer.readableByteCount()];
+            dataBuffer.read(bytes);
+            DataBufferUtils.release(dataBuffer);
+            return bytes;
+        });
+
+        StepVerifier.create(firstRead)
+                .assertNext(bodyRead -> assertArrayEquals(requestBody, bodyRead, "First body read mismatch"))
+                .verifyComplete();
+        StepVerifier.create(secondRead).assertNext(
+                        bodyRead -> assertArrayEquals(requestBody, bodyRead, "Second body read mismatch (not " +
+                                "replayable)"))
+                .verifyComplete();
+
+        verify(mockWebFilterChain).filter(capturedExchange);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "/inbox", "/users/testUser/inbox" })
+    void filter_postToProtectedPath_signatureVerificationSucceeds_withBody_shouldPassThrough(String protectedPath) {
+        byte[] requestBody = "{\"type\":\"Create\"}".getBytes(StandardCharsets.UTF_8);
+        testSuccessfulSignatureVerification(protectedPath, requestBody);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "/inbox", "/users/testUser/inbox" })
+    void filter_postToProtectedPath_signatureVerificationSucceeds_emptyBody_shouldPassThrough(String protectedPath) {
+        byte[] requestBody = new byte[0]; // Empty body
+        testSuccessfulSignatureVerification(protectedPath, requestBody);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "/inbox", "/users/testUser/inbox" })
+    void filterPostToProtectedPathWithBadSignatureShouldReturnUnauthorized(String protectedPath) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Signature", "invalid-signature");
+        byte[] requestBody = "{\"type\":\"Create\"}".getBytes(StandardCharsets.UTF_8);
+        MockServerWebExchange exchange = createExchange(HttpMethod.POST, protectedPath, headers, requestBody);
+
+        when(mockHttpSignatureService.verifySignature(any(ServerWebExchange.class), eq(requestBody))).thenReturn(
+                Mono.just(false));
+
+        StepVerifier.create(httpSignatureWebFilter.filter(exchange, mockWebFilterChain)).verifyComplete();
+
+        verify(mockHttpSignatureService).verifySignature(exchangeCaptor.capture(), bodyBytesCaptor.capture());
+        assertArrayEquals(requestBody, bodyBytesCaptor.getValue());
+
+        assertEquals(HttpStatus.UNAUTHORIZED, exchangeCaptor.getValue().getResponse().getStatusCode());
+        verify(mockWebFilterChain, never()).filter(any());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "/inbox", "/users/testUser/inbox" })
+    void filterPostToProtectedPathWithServiceFailure(String protectedPath) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Signature", "some-signature");
+        byte[] requestBody = "{\"type\":\"Create\"}".getBytes(StandardCharsets.UTF_8);
+        MockServerWebExchange exchange = createExchange(HttpMethod.POST, protectedPath, headers, requestBody);
+
+        RuntimeException serviceException = new RuntimeException("Service failure during signature verification");
+        when(mockHttpSignatureService.verifySignature(any(ServerWebExchange.class), eq(requestBody))).thenReturn(
+                Mono.error(serviceException));
+
+        StepVerifier.create(httpSignatureWebFilter.filter(exchange, mockWebFilterChain))
+                .expectErrorMatches(throwable -> throwable == serviceException).verify();
+
+        verify(mockHttpSignatureService).verifySignature(any(ServerWebExchange.class), bodyBytesCaptor.capture());
+        assertArrayEquals(requestBody, bodyBytesCaptor.getValue());
+        verify(mockWebFilterChain, never()).filter(any());
+    }
+
+    @Test
+    void filterBypassesSignatureCheckForNonProtectedPaths() {
+        HttpHeaders postHeaders = new HttpHeaders();
+        postHeaders.add("Signature", "some-signature"); // Signature present but path is not protected
+        MockServerWebExchange postToNonProtectedPathExchange =
+                createExchange(HttpMethod.POST, "/some/other/public/path", postHeaders, "body".getBytes());
+
+        StepVerifier.create(httpSignatureWebFilter.filter(postToNonProtectedPathExchange, mockWebFilterChain))
+                .verifyComplete();
+
+        verify(mockWebFilterChain).filter(postToNonProtectedPathExchange);
+        verify(mockHttpSignatureService, never()).verifySignature(any(), any());
+    }
+}

--- a/server/src/test/java/edu/sjsu/moth/security/RemotePublicKeyResolverIntegrationTest.java
+++ b/server/src/test/java/edu/sjsu/moth/security/RemotePublicKeyResolverIntegrationTest.java
@@ -51,7 +51,7 @@ class RemotePublicKeyResolverIntegrationTest {
 
     // verifies that RemotePublicKeyResolver can fetch and use it
     @Test
-    void resolve_liveFetchFromMastodonSocial_returnsCorrectPublicKey() {
+    void resolveLiveFetchFromMastodonSocialReturnsCorrectPublicKey() {
         String keyId = "https://mastodon.social/users/divyamonmastodon";
 
         // remove caches specifically for this keyId to ensure a fetch

--- a/server/src/test/java/edu/sjsu/moth/security/RemotePublicKeyResolverIntegrationTest.java
+++ b/server/src/test/java/edu/sjsu/moth/security/RemotePublicKeyResolverIntegrationTest.java
@@ -1,0 +1,83 @@
+package edu.sjsu.moth.security;
+
+import edu.sjsu.moth.server.security.RemotePublicKeyResolver;
+import edu.sjsu.moth.util.HttpSignature;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.security.PublicKey;
+import java.util.Objects;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@Tag("integration")
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = RemotePublicKeyResolverIntegrationTest.TestConfig.class)
+class RemotePublicKeyResolverIntegrationTest {
+
+    // actual PEM for @divyamonmastodon@mastodon.social
+    private static final String DIVYAMONMASTODON_PUBLIC_KEY_PEM = """
+            -----BEGIN PUBLIC KEY-----
+            MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApY9HeTdb75SwnhlEP+JI
+            ZTIt21qmUijBUawLV2A3EHyidqwackn/m31AN+BirhUxmfpPmKwlTMsnPpCWLFA3
+            AGlLJWI3oLfWEJZv8rJpJfNzEbWMMkdJn+3XdN17qxeGjiwOcV00zufIZwpfC08U
+            Jgvsx6Gq25mjxwvHU16qMqBf8wi4mhHxcgJKjvjoJCb9oc2KQpLZkt4ysN0DN+IL
+            Pw39cZcw38CKJnun0DPotH/lWaXT3CM9FmyEpPPl+LHWMkmtwxu/hNYeYsXfyDeR
+            UIStV9wtNi0nb9z+FdxsN9yKSQGzrpoJHOoVN12/irPZdo6adGAS6hQG+pRO901U
+            hwIDAQAB
+            -----END PUBLIC KEY-----
+            """;
+
+    @Autowired
+    private RemotePublicKeyResolver publicKeyResolver;
+    private PublicKey expectedPublicKey;
+
+    @BeforeEach
+    void setUp() {
+        expectedPublicKey = HttpSignature.pemToPublicKey(DIVYAMONMASTODON_PUBLIC_KEY_PEM);
+        assertNotNull(expectedPublicKey, "The known good PEM should be parseable.");
+    }
+
+    // verifies that RemotePublicKeyResolver can fetch and use it
+    @Test
+    void resolve_liveFetchFromMastodonSocial_returnsCorrectPublicKey() {
+        String keyId = "https://mastodon.social/users/divyamonmastodon";
+
+        // remove caches specifically for this keyId to ensure a fetch
+        publicKeyResolver.publicKeyCache.synchronous().invalidate(keyId);
+        publicKeyResolver.negativeLookupCache.synchronous().invalidate(keyId);
+
+        StepVerifier.create(publicKeyResolver.resolve(keyId)).expectSubscription().assertNext(
+                pk -> Assertions.assertArrayEquals(expectedPublicKey.getEncoded(), pk.getEncoded(),
+                                                   "Key material differs")).verifyComplete();
+
+        // optionally verify that it is now in the positive cache
+        StepVerifier.create(
+                        Mono.fromFuture(Objects.requireNonNull(publicKeyResolver.publicKeyCache.getIfPresent(keyId))))
+                .expectNext(expectedPublicKey).verifyComplete();
+    }
+
+    @Configuration
+    static class TestConfig {
+        @Bean
+        public WebClient.Builder webClientBuilder() {
+            return WebClient.builder();
+        }
+
+        @Bean
+        public RemotePublicKeyResolver remotePublicKeyResolver(WebClient.Builder builder) {
+            return new RemotePublicKeyResolver(builder);
+        }
+    }
+}

--- a/server/src/test/java/edu/sjsu/moth/security/RemotePublicKeyResolverTest.java
+++ b/server/src/test/java/edu/sjsu/moth/security/RemotePublicKeyResolverTest.java
@@ -1,0 +1,166 @@
+package edu.sjsu.moth.security;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.sjsu.moth.server.security.RemotePublicKeyResolver;
+import edu.sjsu.moth.util.HttpSignature;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.security.PublicKey;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RemotePublicKeyResolverTest {
+
+    private static final String KNOWN_GOOD_PUBLIC_KEY_PEM = """
+            -----BEGIN PUBLIC KEY-----
+            MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDCFENGw33yGihy92pDjZQhl0C3
+            6rPJj+CvfSC8+q28hxA161QFNUd13wuCTUcq0Qd2qsBe/2hFyc2DCJJg0h1L78+6
+            Z4UMR7EOcpfdUE9Hf3m/hs+FUR45uBJeDK1HSFHD8bHKD6kv8FPGfJTotc+2xjJw
+            oYi+1hqp1fIekaxsyQIDAQAB
+            -----END PUBLIC KEY-----
+            """;
+    private static PublicKey expectedTestPublicKey;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    @Mock
+    private WebClient.Builder webClientBuilderMock;
+    @Mock
+    private WebClient webClientMock;
+    @Mock
+    private WebClient.RequestHeadersUriSpec requestHeadersUriSpecMock;
+    @Mock
+    private WebClient.RequestHeadersSpec requestHeadersSpecMock;
+    @Mock
+    private WebClient.ResponseSpec responseSpecMock;
+    private RemotePublicKeyResolver publicKeyResolver;
+
+    @BeforeEach
+    void setUp() {
+        expectedTestPublicKey = HttpSignature.pemToPublicKey(KNOWN_GOOD_PUBLIC_KEY_PEM);
+
+        lenient().when(webClientBuilderMock.defaultHeader(eq(HttpHeaders.ACCEPT), anyString(), anyString()))
+                .thenReturn(webClientBuilderMock);
+        lenient().when(webClientBuilderMock.build()).thenReturn(webClientMock);
+
+        lenient().when(webClientMock.get()).thenReturn(requestHeadersUriSpecMock);
+        lenient().when(requestHeadersUriSpecMock.uri(any(String.class))).thenReturn(requestHeadersSpecMock);
+        lenient().when(requestHeadersSpecMock.accept(eq(MediaType.valueOf("application/activity+json")),
+                                                     eq(MediaType.APPLICATION_JSON)))
+                .thenReturn(requestHeadersSpecMock);
+        lenient().when(requestHeadersSpecMock.retrieve()).thenReturn(responseSpecMock);
+
+        publicKeyResolver = new RemotePublicKeyResolver(webClientBuilderMock);
+    }
+
+    private JsonNode createActorJsonNode(String pem) {
+        return objectMapper.createObjectNode().put("id", "http://example.com/users/someUser")
+                .set("publicKey", objectMapper.createObjectNode().put("publicKeyPem", pem));
+    }
+
+    private JsonNode createActorJsonNodeWithoutPem() {
+        return objectMapper.createObjectNode().put("id", "http://example.com/users/someUser")
+                .set("publicKey", objectMapper.createObjectNode());
+    }
+
+    @Test
+    void resolveWhenCacheMissAndFetchSuccessWithKnownGoodPemReturnsKeyAndCaches() throws InterruptedException {
+        String keyId = "http://example.com/users/fetchUserGoodKey#main-key";
+        JsonNode actorResponse = createActorJsonNode(KNOWN_GOOD_PUBLIC_KEY_PEM);
+        when(responseSpecMock.bodyToMono(JsonNode.class)).thenReturn(Mono.just(actorResponse));
+
+        StepVerifier.create(publicKeyResolver.resolve(keyId)).expectNext(expectedTestPublicKey).verifyComplete();
+
+        Thread.sleep(100);
+
+        assertNotNull(publicKeyResolver.publicKeyCache.getIfPresent(keyId));
+        assertEquals(expectedTestPublicKey, publicKeyResolver.publicKeyCache.getIfPresent(keyId).join());
+        verify(webClientMock).get();
+    }
+
+    @Test
+    void resolveWhenKeyInPositiveCacheReturnsCachedKeyAndNoNetworkCall() {
+        String keyId = "http://example.com/users/cachedUser#main-key";
+        publicKeyResolver.publicKeyCache.put(keyId, CompletableFuture.completedFuture(expectedTestPublicKey));
+
+        StepVerifier.create(publicKeyResolver.resolve(keyId)).expectNext(expectedTestPublicKey).verifyComplete();
+
+        verify(webClientMock, never()).get();
+    }
+
+    @Test
+    void resolveWhenCacheMissAndFetchNotFoundReturnsEmptyAndCachesNegative() throws InterruptedException {
+        String keyId = "http://example.com/users/notFoundUser#main-key";
+        when(responseSpecMock.bodyToMono(JsonNode.class)).thenReturn(Mono.error(
+                WebClientResponseException.create(HttpStatus.NOT_FOUND.value(), "Not Found", null, null, null)));
+
+        StepVerifier.create(publicKeyResolver.resolve(keyId)).verifyComplete();
+
+        Thread.sleep(100);
+
+        assertNotNull(publicKeyResolver.negativeLookupCache.getIfPresent(keyId));
+        verify(webClientMock).get();
+    }
+
+    @Test
+    void resolveWhenKeyInNegativeCacheReturnsEmptyAndNoNetworkCall() {
+        String keyId = "http://example.com/users/negCachedUser#main-key";
+        publicKeyResolver.negativeLookupCache.put(keyId, CompletableFuture.completedFuture(
+                RemotePublicKeyResolver.NEGATIVE_CACHE_SENTINEL));
+
+        StepVerifier.create(publicKeyResolver.resolve(keyId)).verifyComplete();
+
+        verify(webClientMock, never()).get();
+    }
+
+    @Test
+    void resolveWhenCacheMissAndActorMissingPemReturnsEmptyAndCachesNegative() throws InterruptedException {
+        String keyId = "http://example.com/users/noPemUser#main-key";
+        JsonNode actorResponse = createActorJsonNodeWithoutPem();
+        when(responseSpecMock.bodyToMono(JsonNode.class)).thenReturn(Mono.just(actorResponse));
+
+        StepVerifier.create(publicKeyResolver.resolve(keyId)).verifyComplete();
+
+        Thread.sleep(100);
+
+        assertNotNull(publicKeyResolver.negativeLookupCache.getIfPresent(keyId));
+        verify(webClientMock).get();
+    }
+
+    @Test
+    void resolveWhenCacheMissAndInvalidPemFormatInResponseReturnsEmptyAndCachesNegative() throws InterruptedException {
+        String keyId = "http://example.com/users/invalidPemUser#main-key";
+        JsonNode actorResponse = createActorJsonNode("THIS IS NOT A VALID PEM AT ALL TRUST ME ");
+        when(responseSpecMock.bodyToMono(JsonNode.class)).thenReturn(Mono.just(actorResponse));
+
+        StepVerifier.create(publicKeyResolver.resolve(keyId)).verifyComplete();
+
+        Thread.sleep(100);
+
+        assertNotNull(publicKeyResolver.negativeLookupCache.getIfPresent(keyId),
+                      "Key should be in negative cache due to invalid PEM");
+        assertNull(publicKeyResolver.publicKeyCache.getIfPresent(keyId), "Key should not be in positive cache");
+        verify(webClientMock).get();
+    }
+}

--- a/server/src/test/java/edu/sjsu/moth/service/HttpSignatureServiceTest.java
+++ b/server/src/test/java/edu/sjsu/moth/service/HttpSignatureServiceTest.java
@@ -78,7 +78,7 @@ class HttpSignatureServiceTest {
             """;
     private static final PublicKey HARDCODED_PUBLIC_KEY = HttpSignature.pemToPublicKey(HARDCODED_PUBLIC_KEY_PEM);
     private static final String TEST_ACCOUNT_ID = "testuser";
-    private static final String TEST_SERVER_NAME = "test.server"; // Assuming this value
+    private static final String TEST_SERVER_NAME = "localhost"; // Assuming this value
     private static final String EXPECTED_KEY_ID =
             "https://" + TEST_SERVER_NAME + "/users/" + TEST_ACCOUNT_ID + "#main-key";
     private static final URI TEST_TARGET_URI = URI.create("https://verify.example.com/inbox");

--- a/server/src/test/java/edu/sjsu/moth/service/HttpSignatureServiceTest.java
+++ b/server/src/test/java/edu/sjsu/moth/service/HttpSignatureServiceTest.java
@@ -2,28 +2,22 @@ package edu.sjsu.moth.service;
 
 import edu.sjsu.moth.server.db.PubKeyPair;
 import edu.sjsu.moth.server.db.PubKeyPairRepository;
+import edu.sjsu.moth.server.security.PublicKeyResolver;
 import edu.sjsu.moth.server.service.HttpSignatureService;
 import edu.sjsu.moth.server.util.MothConfiguration;
 import edu.sjsu.moth.util.HttpSignature;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
-import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.core.io.buffer.DataBufferFactory;
 import org.springframework.core.io.buffer.DefaultDataBufferFactory;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
 import org.springframework.mock.web.server.MockServerWebExchange;
-import org.springframework.util.MultiValueMapAdapter;
-import org.springframework.web.reactive.function.client.ClientRequest;
-import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -33,38 +27,29 @@ import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
-import static edu.sjsu.moth.server.util.MothConfiguration.mothConfiguration;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.util.AssertionErrors.assertEquals;
-import static org.springframework.test.util.AssertionErrors.assertNotNull;
 
 @ExtendWith(MockitoExtension.class)
 class HttpSignatureServiceTest {
 
-    public static final URI example_uri = URI.create("/foo?param=value&pet=dog");
-    public static final byte[] EXAMPLE_BODY = "{\"hello\": \"world\"}".getBytes();
+    public static final byte[] EXAMPLE_BODY = "{\"hello\": \"world\"}".getBytes(StandardCharsets.UTF_8);
     private static final String HARDCODED_PUBLIC_KEY_PEM = """
             -----BEGIN PUBLIC KEY-----
             MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDCFENGw33yGihy92pDjZQhl0C3
@@ -96,18 +81,13 @@ class HttpSignatureServiceTest {
     private static final String TEST_SERVER_NAME = "test.server"; // Assuming this value
     private static final String EXPECTED_KEY_ID =
             "https://" + TEST_SERVER_NAME + "/users/" + TEST_ACCOUNT_ID + "#main-key";
-    private static final Pattern HEADERS_PATTERN = Pattern.compile("headers=\"([^\"]+)\"");
     private static final URI TEST_TARGET_URI = URI.create("https://verify.example.com/inbox");
-    public static HttpHeaders example_headers = new HttpHeaders(new MultiValueMapAdapter<>(
-            Map.of("host", List.of("example.com"), "date", List.of("Sun, 05 Jan 2014 21:31:40 GMT"), "content-Type",
-                   List.of("application/json"), "content-Length", List.of("18"))));
     private final DataBufferFactory dataBufferFactory = new DefaultDataBufferFactory();
     @Mock
     private PubKeyPairRepository pubKeyPairRepository;
     @Mock
-    private WebClient.Builder webClientBuilder;
-    @Mock
-    private WebClient webClient;
+    private PublicKeyResolver publicKeyResolver;
+
     private HttpSignatureService httpSignatureService;
 
     @BeforeAll
@@ -116,244 +96,110 @@ class HttpSignatureServiceTest {
         new MothConfiguration(new File(fullPath));
     }
 
-    private static @NotNull String generateC2InvalidSignature(String correctKeyId) {
-        String correctSignedHeaders = "(request-target) host date"; // Type C2 does not have digest
-        String correctSignatureValue = "qdx+H7PHHDZgy4y/Ahn9Tny9V3GP6YgBPyUXMmoxWtLbHpUnXS2mg2" +
-                "+SbrQDMCJypxBLSPQR2aAjn7ndmw2iicw3HMbe8VfEdKFYRqzic+efkb3nndiv" +
-                "/x1xSHDJWeSWkx3ButlYSuBskLu6kd9Fswtemr3lgdDEmn04swr2Os0=";
-        String invalidSignatureValue = correctSignatureValue.replace("qdx", "xxx");
-
-        return String.format("keyId=\"%s\",headers=\"%s\",signature=\"%s\"", correctKeyId, correctSignedHeaders,
-                             invalidSignatureValue);
-    }
-
     @BeforeEach
     void setUp() {
-        when(webClientBuilder.defaultHeader(anyString(), any(String[].class))).thenReturn(webClientBuilder);
-        when(webClientBuilder.build()).thenReturn(webClient);
-
-        httpSignatureService = spy(new HttpSignatureService(pubKeyPairRepository, webClientBuilder));
+        httpSignatureService = new HttpSignatureService(pubKeyPairRepository, publicKeyResolver);
     }
 
+    // test cases for prepareSignedHeaders method
     @Test
-    void signRequestHappyPathWithBodyShouldAddSignatureAndDigest() throws NoSuchAlgorithmException { // Added
+    void prepareSignedHeadersPOSTWithBodyShouldCreateCorrectHeaders() {
         PubKeyPair keyPair = new PubKeyPair(TEST_ACCOUNT_ID, HARDCODED_PUBLIC_KEY_PEM, HARDCODED_PRIVATE_KEY_PEM);
         when(pubKeyPairRepository.findItemByAcct(TEST_ACCOUNT_ID)).thenReturn(Mono.just(keyPair));
-        String requestBody = "{\"activity\": \"create\"}";
-        byte[] requestBodyBytes = requestBody.getBytes(StandardCharsets.UTF_8);
-        MessageDigest digest = MessageDigest.getInstance("SHA-256");
-        byte[] hash = digest.digest(requestBodyBytes);
-        String expectedDigestValue = "SHA-256=" + Base64.getEncoder().encodeToString(hash);
-        Flux<DataBuffer> fluxBody = Flux.just(dataBufferFactory.wrap(requestBodyBytes));
 
-        ClientRequest originalRequest =
-                ClientRequest.create(HttpMethod.POST, URI.create("https://remote.example/inbox"))
-                        .header(HttpHeaders.HOST, "remote.example") // Host is usually needed for signature
-                        .body(fluxBody, DataBuffer.class).build();
-        Mono<ClientRequest> signedRequestMono =
-                httpSignatureService.signRequest(originalRequest, TEST_ACCOUNT_ID, requestBodyBytes);
+        URI targetUri = URI.create("https://target.example.com/inbox");
 
-        StepVerifier.create(signedRequestMono).expectNextMatches(signedRequest -> {
-            HttpHeaders headers = signedRequest.headers();
-            assertTrue(headers.containsKey("Digest"), "Should contain Digest header");
-            assertEquals("Digest header value mismatch", expectedDigestValue.substring(3),
-                         Objects.requireNonNull(headers.getFirst("Digest")).substring(3));
+        Mono<HttpHeaders> headersMono =
+                httpSignatureService.prepareSignedHeaders(HttpMethod.POST, TEST_ACCOUNT_ID, targetUri, EXAMPLE_BODY);
+
+        StepVerifier.create(headersMono).expectNextMatches(headers -> {
             assertTrue(headers.containsKey(HttpHeaders.DATE), "Should contain Date header");
+            assertEquals("Host header mismatch", targetUri.getHost(), headers.getFirst(HttpHeaders.HOST));
+            assertTrue(headers.containsKey("Digest"), "Should contain Digest header");
             assertTrue(headers.containsKey("Signature"), "Should contain Signature header");
-            String sigHeader = headers.getFirst("Signature");
-            assertNotNull(sigHeader, "Signature header should not be null");
-            assert sigHeader != null;
-            assertTrue(sigHeader.contains("keyId"), "Signature keyId mismatch");
-            assertTrue(sigHeader.contains("signature=\""), "Signature should contain signature part");
-            Matcher matcher = HEADERS_PATTERN.matcher(sigHeader);
-            assertTrue(matcher.find(), "Could not find headers part in Signature");
-            String signedHeadersString = matcher.group(1);
-            assertNotNull(signedHeadersString, "Signed headers string is null");
-            List<String> signedHeadersList = List.of(signedHeadersString.toLowerCase().split(" "));
-            assertTrue(signedHeadersList.contains("(request-target)"),
-                       "Signature headers should include (request-target)");
-            assertTrue(signedHeadersList.contains("host"), "Signature headers should include host");
-            assertTrue(signedHeadersList.contains("date"), "Signature headers should include date");
 
+            String sigHeader = headers.getFirst("Signature");
+            assertNotNull(sigHeader, "Signature header is null");
+            assertTrue(sigHeader.contains("keyId=\"" + EXPECTED_KEY_ID + "\""),
+                       "keyId mismatch in Signature. Expected: " + EXPECTED_KEY_ID + " Got: " + sigHeader);
+
+            Map<String, String> sigFields = HttpSignature.extractFields(sigHeader);
+            String signedHeadersString = sigFields.get("headers");
+            assertNotNull(signedHeadersString, "headers field missing in Signature");
+            List<String> signedHeadersList = List.of(signedHeadersString.toLowerCase().split(" "));
+            assertTrue(signedHeadersList.containsAll(List.of("(request-target)", "host", "date", "digest")),
+                       "Signed headers list mismatch for POST");
             return true;
         }).verifyComplete();
     }
 
     @Test
-    void testSignRequestHappyPathWithoutBodyShouldAddSignature() {
+    void prepareSignedHeadersGETWithoutBodyShouldCreateCorrectHeaders() {
         PubKeyPair keyPair = new PubKeyPair(TEST_ACCOUNT_ID, HARDCODED_PUBLIC_KEY_PEM, HARDCODED_PRIVATE_KEY_PEM);
         when(pubKeyPairRepository.findItemByAcct(TEST_ACCOUNT_ID)).thenReturn(Mono.just(keyPair));
 
-        ClientRequest originalRequest = ClientRequest.create(HttpMethod.GET, URI.create("https://remote.example/actor"))
-                .header(HttpHeaders.HOST, "remote.example").build();
-        Mono<ClientRequest> signedRequestMono =
-                httpSignatureService.signRequest(originalRequest, TEST_ACCOUNT_ID, null);
+        URI targetUri = URI.create("https://target.example.com/actor");
 
-        StepVerifier.create(signedRequestMono).expectNextMatches(signedRequest -> {
-            HttpHeaders headers = signedRequest.headers();
-            assertFalse(headers.containsKey("Digest"), "Should NOT contain Digest header for GET request");
+        Mono<HttpHeaders> headersMono =
+                httpSignatureService.prepareSignedHeaders(HttpMethod.GET, TEST_ACCOUNT_ID, targetUri, null);
+
+        StepVerifier.create(headersMono).expectNextMatches(headers -> {
+            assertTrue(headers.containsKey(HttpHeaders.DATE), "Should contain Date header");
+            assertEquals("Host header mismatch", targetUri.getHost(), headers.getFirst(HttpHeaders.HOST));
+            assertTrue(headers.containsKey(HttpHeaders.ACCEPT), "Should contain Accept header");
+            assertFalse(headers.containsKey("Digest"), "Should NOT contain Digest header for GET");
+            assertFalse(headers.containsKey(HttpHeaders.CONTENT_TYPE), "Should NOT contain Content-Type for GET");
             assertTrue(headers.containsKey("Signature"), "Should contain Signature header");
+
             String sigHeader = headers.getFirst("Signature");
-            assertNotNull(sigHeader, "Signature header should not be null");
             assert sigHeader != null;
-            assertTrue(sigHeader.contains("keyId"), "Signature keyId mismatch");
-            assertTrue(sigHeader.contains("signature=\""), "Signature should contain signature part");
-            Matcher matcher = HEADERS_PATTERN.matcher(sigHeader);
-            assertTrue(matcher.find(), "Could not find headers part in Signature");
-            String signedHeadersString = matcher.group(1);
-            assertNotNull(signedHeadersString, "Signed headers string is null");
+            assertTrue(sigHeader.contains("keyId=\"" + EXPECTED_KEY_ID + "\""), "keyId mismatch");
+            Map<String, String> sigFields = HttpSignature.extractFields(sigHeader);
+            String signedHeadersString = sigFields.get("headers");
             List<String> signedHeadersList = List.of(signedHeadersString.toLowerCase().split(" "));
-            assertTrue(signedHeadersList.contains("(request-target)"),
-                       "Signature headers should include (request-target)");
-            assertTrue(signedHeadersList.contains("host"), "Signature headers should include host");
-            assertTrue(signedHeadersList.contains("date"), "Signature headers should include date");
-            assertFalse(signedHeadersList.contains("digest"), "Signature headers should NOT include digest");
-            return true;
-        }).verifyComplete();
-    }
-
-    /*
-     * example request from spec:
-     *  POST /foo?param=value&pet=dog HTTP/1.1
-     * Host: example.com
-     * Date: Sun, 05 Jan 2014 21:31:40 GMT
-     * Content-Type: application/json
-     * Digest: SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=
-     * Content-Length: 18
-     *
-     *{"hello": "world"}
-     */
-    // https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures-12#appendix-C.2
-    @Test
-    void signRequestC2ShouldGenerateCorrectSignature() {
-        // C2 body
-        HttpMethod method = HttpMethod.POST;
-        URI c2RequestUri = URI.create("https://example.com/foo?param=value&pet=dog");
-        String c2TestAccountID = "C2TestAccount";
-        HttpHeaders initialHeaders = new HttpHeaders();
-        initialHeaders.setAll(example_headers.toSingleValueMap());
-        initialHeaders.set(HttpHeaders.HOST, "example.com");
-        initialHeaders.set(HttpHeaders.DATE, "Sun, 05 Jan 2014 21:31:40 GMT");
-
-        PubKeyPair c2KeyPair = new PubKeyPair(c2TestAccountID, HARDCODED_PUBLIC_KEY_PEM, HARDCODED_PRIVATE_KEY_PEM);
-        when(pubKeyPairRepository.findItemByAcct(c2TestAccountID)).thenReturn(Mono.just(c2KeyPair));
-
-        ClientRequest originalRequest =
-                ClientRequest.create(method, c2RequestUri).headers(h -> h.addAll(initialHeaders))
-                        // C2 signature doesn't include digest
-                        .build();
-
-        String expectedC2SignatureValue = "qdx+H7PHHDZgy4y/Ahn9Tny9V3GP6YgBPyUXMmoxWtLbHpUnXS2mg2" +
-                "+SbrQDMCJypxBLSPQR2aAjn7ndmw2iicw3HMbe8VfEdKFYRqzic+efkb3nndiv" +
-                "/x1xSHDJWeSWkx3ButlYSuBskLu6kd9Fswtemr3lgdDEmn04swr2Os0=";
-        String expectedC2HeadersField = "(request-target) host date";
-
-        ClientRequest signedRequest = httpSignatureService.signRequest(originalRequest, c2TestAccountID, null).block();
-
-        assertNotNull(String.valueOf(signedRequest), "Signed request should not be null");
-        assert signedRequest != null;
-        HttpHeaders signedHeaders = signedRequest.headers();
-        assertTrue(signedHeaders.containsKey("Signature"), "Signature header missing after signing");
-        assertFalse(signedHeaders.containsKey("Digest"), "Digest header should not be present for null body");
-
-        String actualSignatureHeader = signedHeaders.getFirst("Signature");
-        assertNotNull(actualSignatureHeader, "Signature header value is null");
-
-        // Verify signature value with expected value
-        String actualSignatureValue = HttpSignature.extractFields(actualSignatureHeader).get("signature");
-        assertEquals("Generated signature value does not match C.2 example", expectedC2SignatureValue,
-                     actualSignatureValue);
-
-        // C2 Signature should only have "(request-target), host, and date"
-        String actualHeadersField = HttpSignature.extractFields(actualSignatureHeader).get("headers");
-        assertEquals("Signed headers field is incorrect", expectedC2HeadersField, actualHeadersField.toLowerCase());
-    }
-
-    // Verifies Date, Host Header is added with correct values
-    @Test
-    void signRequestAddsDateAndHostHeaders_WhenMissing() {
-        String accountId = TEST_ACCOUNT_ID;
-        URI requestUri = URI.create("https://some.target.host/api/v1/resource");
-        String expectedHost = requestUri.getHost(); // "some.target.host"
-        String expectedDate = DateTimeFormatter.RFC_1123_DATE_TIME.format(ZonedDateTime.now(ZoneOffset.UTC));
-        PubKeyPair keyPair = new PubKeyPair(accountId, HARDCODED_PUBLIC_KEY_PEM, HARDCODED_PRIVATE_KEY_PEM);
-        when(pubKeyPairRepository.findItemByAcct(accountId)).thenReturn(Mono.just(keyPair));
-
-        ClientRequest originalRequest = ClientRequest.create(HttpMethod.GET, requestUri).build();
-        Mono<ClientRequest> signedRequestMono = httpSignatureService.signRequest(originalRequest, accountId, null);
-
-        StepVerifier.create(signedRequestMono).expectNextMatches(signedRequest -> {
-            HttpHeaders headers = signedRequest.headers();
-            assertTrue(headers.containsKey(HttpHeaders.DATE), "Date header should be added");
-            assertEquals("Added Date header value mismatch", expectedDate, headers.getFirst(HttpHeaders.DATE));
-            assertTrue(headers.containsKey(HttpHeaders.HOST), "Host header should be added");
-            assertEquals("Added Host header value mismatch", expectedHost, headers.getFirst(HttpHeaders.HOST));
-            assertTrue(headers.containsKey("Signature"), "Signature header should be present");
-
+            assertTrue(signedHeadersList.containsAll(List.of("(request-target)", "host", "date")),
+                       "Signed headers list mismatch for GET");
+            assertFalse(signedHeadersList.contains("digest"), "Digest should not be in signed headers for GET");
             return true;
         }).verifyComplete();
     }
 
     @Test
-    void signRequestShouldNotAddDateAndHostHeaders() {
-        String accountId = TEST_ACCOUNT_ID;
-        URI requestUri = URI.create("https://provided.host/specific/path");
-        String predefinedHost = "provided.host";
-        String predefinedDate = "Tue, 29 Feb 2000 12:00:00 GMT";
+    void prepareSignedHeadersKeyNotFoundShouldReturnError() {
+        when(pubKeyPairRepository.findItemByAcct(TEST_ACCOUNT_ID)).thenReturn(Mono.empty());
+        URI targetUri = URI.create("https://target.example.com/inbox");
+        Mono<HttpHeaders> headersMono =
+                httpSignatureService.prepareSignedHeaders(HttpMethod.POST, TEST_ACCOUNT_ID, targetUri, EXAMPLE_BODY);
 
-        PubKeyPair keyPair = new PubKeyPair(accountId, HARDCODED_PUBLIC_KEY_PEM, HARDCODED_PRIVATE_KEY_PEM);
-        when(pubKeyPairRepository.findItemByAcct(accountId)).thenReturn(Mono.just(keyPair));
-
-        ClientRequest originalRequest =
-                ClientRequest.create(HttpMethod.GET, requestUri).header(HttpHeaders.HOST, predefinedHost)
-                        .header(HttpHeaders.DATE, predefinedDate).build();
-        Mono<ClientRequest> signedRequestMono =
-                httpSignatureService.signRequest(originalRequest, accountId, null); // Body null for simplicity
-
-        StepVerifier.create(signedRequestMono).expectNextMatches(signedRequest -> {
-            HttpHeaders headers = signedRequest.headers();
-            assertTrue(headers.containsKey(HttpHeaders.HOST), "Host header should still be present");
-            assertEquals("Existing Host header value mismatch", predefinedHost, headers.getFirst(HttpHeaders.HOST));
-            assertTrue(headers.containsKey(HttpHeaders.DATE), "Date header should still be present");
-            assertEquals("Existing Date header value mismatch", predefinedDate, headers.getFirst(HttpHeaders.DATE));
-
-            return true;
-        }).verifyComplete();
+        StepVerifier.create(headersMono).expectErrorMessage("Private key not found for actor: " + TEST_ACCOUNT_ID)
+                .verify();
     }
 
     @Test
-    void signRequestShouldContainCorrectKeyId() {
-        String accountId = TEST_ACCOUNT_ID;
-        URI requestUri = URI.create("https://some.target.host/api/v1/resource");
-        String expectedServerName = mothConfiguration.getServerName();
-        String expectedKeyId = "https://" + expectedServerName + "/users/" + accountId + "#main-key";
-        PubKeyPair keyPair = new PubKeyPair(accountId, HARDCODED_PUBLIC_KEY_PEM, HARDCODED_PRIVATE_KEY_PEM);
-        when(pubKeyPairRepository.findItemByAcct(accountId)).thenReturn(Mono.just(keyPair));
+    void prepareSignedHeadersSignatureGenerationExceptionShouldReturnError() {
+        // PEM to PrivateKey conversion fails
+        PubKeyPair keyPairWithBadKey =
+                new PubKeyPair(TEST_ACCOUNT_ID, HARDCODED_PUBLIC_KEY_PEM, "ofc invalid private key data!");
+        when(pubKeyPairRepository.findItemByAcct(TEST_ACCOUNT_ID)).thenReturn(Mono.just(keyPairWithBadKey));
+        URI targetUri = URI.create("https://target.example.com/inbox");
 
-        ClientRequest originalRequest =
-                ClientRequest.create(HttpMethod.GET, requestUri).header(HttpHeaders.HOST, requestUri.getHost()).build();
-        Mono<ClientRequest> signedRequestMono = httpSignatureService.signRequest(originalRequest, accountId, null);
-        StepVerifier.create(signedRequestMono).expectNextMatches(signedRequest -> {
-            HttpHeaders headers = signedRequest.headers();
-            String signatureHeaderValue = headers.getFirst("Signature");
-            String expectedKeyIdParam = "keyId=\"" + expectedKeyId + "\"";
-            assert signatureHeaderValue != null;
-            assertTrue(signatureHeaderValue.contains(expectedKeyIdParam),
-                       "Signature header should contain correct keyId parameter");
-            return true;
-        }).verifyComplete();
+        Mono<HttpHeaders> headersMono =
+                httpSignatureService.prepareSignedHeaders(HttpMethod.POST, TEST_ACCOUNT_ID, targetUri, EXAMPLE_BODY);
+
+        StepVerifier.create(headersMono).expectErrorMatches(throwable -> throwable instanceof RuntimeException &&
+                "Failed to prepare signed headers".equals(throwable.getMessage())).verify();
     }
+
+    // test cases for verifySignature method
 
     @Test
     void verifySignatureMissingSignatureHeaderShouldReturnFalse() {
-        // https://stackoverflow.com/questions/47878963/mockito-fails-with-inlined-mocks-enabled-with-invalid-paramter-name-exception
         MockServerHttpRequest mockServerRequest = MockServerHttpRequest.get(TEST_TARGET_URI.toString()).build();
         MockServerWebExchange mockExchange = MockServerWebExchange.from(mockServerRequest);
-        Mono<Boolean> verificationResultMono = httpSignatureService.verifySignature(mockExchange);
+        Mono<Boolean> verificationResultMono = httpSignatureService.verifySignature(mockExchange, new byte[0]);
 
         StepVerifier.create(verificationResultMono).expectNext(false).verifyComplete();
-
-        verify(httpSignatureService, never()).fetchPublicKey(anyString());
+        verify(publicKeyResolver, never()).resolve(anyString());
     }
 
     @Test
@@ -361,6 +207,7 @@ class HttpSignatureServiceTest {
         HttpHeaders headers = new HttpHeaders();
         headers.add(HttpHeaders.DATE, HttpSignatureService.formatHttpDate(ZonedDateTime.now(ZoneOffset.UTC)));
         headers.add(HttpHeaders.HOST, TEST_TARGET_URI.getHost());
+        // for GET digest is not required to be signed
         String signatureHeader = "keyId=\"" + EXPECTED_KEY_ID +
                 "\",headers=\"(request-target) host date\",signature=\"invalidsignaturevalue\"";
         headers.add("Signature", signatureHeader);
@@ -370,34 +217,14 @@ class HttpSignatureServiceTest {
         MockServerWebExchange mockExchange = MockServerWebExchange.from(mockServerRequest);
 
         assert HARDCODED_PUBLIC_KEY != null;
-        doReturn(Mono.just(HARDCODED_PUBLIC_KEY)).when(httpSignatureService).fetchPublicKey(eq(EXPECTED_KEY_ID));
-        Mono<Boolean> verificationResultMono = httpSignatureService.verifySignature(mockExchange);
-        StepVerifier.create(verificationResultMono).expectNext(false).verifyComplete();
-    }
+        when(publicKeyResolver.resolve(eq(EXPECTED_KEY_ID))).thenReturn(Mono.just(HARDCODED_PUBLIC_KEY));
 
-    @MockitoSettings(strictness = Strictness.LENIENT)
-    @Test
-    void verifySignatureInvalidSignatureValueUsingC2DataShouldReturnFalse() {
-        HttpHeaders c2Headers = new HttpHeaders();
-        c2Headers.addAll(example_headers);
-        String correctKeyId = "Test";
-        String signatureHeaderWithInvalidSig = generateC2InvalidSignature(correctKeyId);
-        c2Headers.set("Signature", signatureHeaderWithInvalidSig);
-
-        URI fullRequestUri = URI.create("https://example.com" + example_uri);
-        MockServerHttpRequest mockServerRequest =
-                MockServerHttpRequest.post(fullRequestUri.toString()).headers(c2Headers).build();
-        MockServerWebExchange mockExchange = MockServerWebExchange.from(mockServerRequest);
-        assert HARDCODED_PUBLIC_KEY != null;
-        doReturn(Mono.just(HARDCODED_PUBLIC_KEY)).when(httpSignatureService).fetchPublicKey(eq(correctKeyId));
-
-        // https://stackoverflow.com/questions/20551926/exception-mockito-wanted-but-not-invoked-actually-there-were-zero-interaction
-        Mono<Boolean> verificationResultMono = httpSignatureService.verifySignature(mockExchange);
+        Mono<Boolean> verificationResultMono = httpSignatureService.verifySignature(mockExchange, new byte[0]);
         StepVerifier.create(verificationResultMono).expectNext(false).verifyComplete();
     }
 
     @Test
-    void verifySignature_ExpiredDateHeader_ShouldReturnFalse() {
+    void verifySignatureExpiredDateHeaderShouldReturnFalse() {
         HttpHeaders headers = new HttpHeaders();
         String expiredDate = HttpSignatureService.formatHttpDate(ZonedDateTime.now(ZoneOffset.UTC).minusHours(25));
         headers.add(HttpHeaders.DATE, expiredDate);
@@ -409,64 +236,216 @@ class HttpSignatureServiceTest {
         MockServerHttpRequest mockServerRequest =
                 MockServerHttpRequest.get(TEST_TARGET_URI.toString()).headers(headers).build();
         MockServerWebExchange mockExchange = MockServerWebExchange.from(mockServerRequest);
-        Mono<Boolean> verificationResultMono = httpSignatureService.verifySignature(mockExchange);
-        StepVerifier.create(verificationResultMono).expectNext(false).verifyComplete();
+        Mono<Boolean> verificationResultMono = httpSignatureService.verifySignature(mockExchange, new byte[0]);
 
-        verify(httpSignatureService, never()).fetchPublicKey(anyString());
+        StepVerifier.create(verificationResultMono).expectNext(false).verifyComplete();
+        verify(publicKeyResolver, never()).resolve(anyString());
     }
 
     @Test
-    void verifySignatureFetchPublicKeyFailsShouldReturnFalse() {
+    void verifySignaturePublicKeyResolverFailsShouldReturnFalse() {
         HttpHeaders headers = new HttpHeaders();
         headers.add(HttpHeaders.DATE, HttpSignatureService.formatHttpDate(ZonedDateTime.now(ZoneOffset.UTC)));
         headers.add(HttpHeaders.HOST, TEST_TARGET_URI.getHost());
-        String signatureHeader = "keyId=\"" + EXPECTED_KEY_ID +
-                "\",headers=\"(request-target) host date\",signature=\"validlooking\""; // signature value doesn't
+        String signatureHeader =
+                "keyId=\"" + EXPECTED_KEY_ID + "\",headers=\"(request-target) host date\",signature=\"validlooking\"";
         headers.add("Signature", signatureHeader);
 
         MockServerHttpRequest mockServerRequest =
                 MockServerHttpRequest.get(TEST_TARGET_URI.toString()).headers(headers).build();
         MockServerWebExchange mockExchange = MockServerWebExchange.from(mockServerRequest);
 
-        doReturn(Mono.empty()).when(httpSignatureService).fetchPublicKey(eq(EXPECTED_KEY_ID));
-        Mono<Boolean> verificationResultMono = httpSignatureService.verifySignature(mockExchange);
+        when(publicKeyResolver.resolve(eq(EXPECTED_KEY_ID))).thenReturn(Mono.empty());
+        Mono<Boolean> verificationResultMono = httpSignatureService.verifySignature(mockExchange, new byte[0]);
         StepVerifier.create(verificationResultMono).expectNext(false).verifyComplete();
-        verify(httpSignatureService, times(1)).fetchPublicKey(eq(EXPECTED_KEY_ID));
+        verify(publicKeyResolver, times(1)).resolve(eq(EXPECTED_KEY_ID));
+    }
+
+    // missing 'date' or '(created)' in headers
+    @Test
+    void verifySignatureWithMissingDateOrCreatedInSignedHeadersShouldReturnFalse() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.DATE, HttpSignatureService.formatHttpDate(ZonedDateTime.now(ZoneOffset.UTC)));
+        headers.add(HttpHeaders.HOST, TEST_TARGET_URI.getHost());
+        String signatureHeader =
+                "keyId=\"" + EXPECTED_KEY_ID + "\",headers=\"(request-target) host\",signature=\"somesig\"";
+        headers.add("Signature", signatureHeader);
+        MockServerHttpRequest req = MockServerHttpRequest.get(TEST_TARGET_URI.toString()).headers(headers).build();
+        Mono<Boolean> result = httpSignatureService.verifySignature(MockServerWebExchange.from(req), new byte[0]);
+        StepVerifier.create(result).expectNext(false).verifyComplete();
+    }
+
+    // missing '(request-target)' and 'digest' in headers
+    @Test
+    void verifySignatureWithMissingRequestTargetOrDigestInSignedHeadersShouldReturnFalse() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.DATE, HttpSignatureService.formatHttpDate(ZonedDateTime.now(ZoneOffset.UTC)));
+        headers.add(HttpHeaders.HOST, TEST_TARGET_URI.getHost());
+        String signatureHeader = "keyId=\"" + EXPECTED_KEY_ID + "\",headers=\"host date\",signature=\"somesig\"";
+        headers.add("Signature", signatureHeader);
+        MockServerHttpRequest req = MockServerHttpRequest.get(TEST_TARGET_URI.toString()).headers(headers).build();
+        Mono<Boolean> result = httpSignatureService.verifySignature(MockServerWebExchange.from(req), new byte[0]);
+        StepVerifier.create(result).expectNext(false).verifyComplete();
+    }
+
+    // missing 'host' in headers for GET request
+    @Test
+    void verifySignatureWithGETMissingHostInSignedHeadersShouldReturnFalse() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.DATE, HttpSignatureService.formatHttpDate(ZonedDateTime.now(ZoneOffset.UTC)));
+        headers.add(HttpHeaders.HOST, TEST_TARGET_URI.getHost());
+        String signatureHeader =
+                "keyId=\"" + EXPECTED_KEY_ID + "\",headers=\"(request-target) date\",signature=\"somesig\"";
+        headers.add("Signature", signatureHeader);
+        MockServerHttpRequest req = MockServerHttpRequest.get(TEST_TARGET_URI.toString()).headers(headers).build();
+        Mono<Boolean> result = httpSignatureService.verifySignature(MockServerWebExchange.from(req), new byte[0]);
+        StepVerifier.create(result).expectNext(false).verifyComplete();
+    }
+
+    // missing 'digest' in headers to verify for POST request
+    @Test
+    void verifySignatureWithPOSTMissingDigestInSignedHeadersShouldReturnFalse() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.DATE, HttpSignatureService.formatHttpDate(ZonedDateTime.now(ZoneOffset.UTC)));
+        headers.add(HttpHeaders.HOST, TEST_TARGET_URI.getHost());
+
+        headers.add("Digest", "SHA-256=" +
+                Base64.getEncoder().encodeToString(HttpSignature.newSHA256Digest().digest(EXAMPLE_BODY)));
+        String signatureHeader =
+                "keyId=\"" + EXPECTED_KEY_ID + "\",headers=\"(request-target) host date\",signature=\"somesig\"";
+        headers.add("Signature", signatureHeader);
+        MockServerHttpRequest req = MockServerHttpRequest.post(TEST_TARGET_URI.toString()).headers(headers).build();
+        Mono<Boolean> result = httpSignatureService.verifySignature(MockServerWebExchange.from(req), EXAMPLE_BODY);
+        StepVerifier.create(result).expectNext(false).verifyComplete();
     }
 
     @Test
-    void signThenVerifyHappyPathWithBody() {
-        HttpMethod method = HttpMethod.POST;
-        when(pubKeyPairRepository.findItemByAcct(TEST_ACCOUNT_ID)).thenReturn(
-                Mono.just(new PubKeyPair(TEST_ACCOUNT_ID, HARDCODED_PUBLIC_KEY_PEM, HARDCODED_PRIVATE_KEY_PEM)));
-        ClientRequest originalRequest =
-                ClientRequest.create(method, TEST_TARGET_URI).header(HttpHeaders.HOST, TEST_TARGET_URI.getHost())
-                        .body(Flux.just(dataBufferFactory.wrap(EXAMPLE_BODY)), DataBuffer.class).build();
+    void verifySignaturePOSTWithCorrectDigestInHeaderAndBodyShouldReturnTrue() {
+        // Prepare signed headers
+        PubKeyPair keyPair = new PubKeyPair(TEST_ACCOUNT_ID, HARDCODED_PUBLIC_KEY_PEM, HARDCODED_PRIVATE_KEY_PEM);
+        when(pubKeyPairRepository.findItemByAcct(TEST_ACCOUNT_ID)).thenReturn(Mono.just(keyPair));
 
-        Mono<ClientRequest> signedRequestMono =
-                httpSignatureService.signRequest(originalRequest, TEST_ACCOUNT_ID, EXAMPLE_BODY);
-        ClientRequest signedRequest = signedRequestMono.block();
-        assertNotNull(String.valueOf(signedRequest), "Signed request mono resolved to null");
-        assert signedRequest != null;
-        HttpHeaders signedHeaders = signedRequest.headers();
-        assertTrue(signedHeaders.containsKey("Signature"), "Signature header should be present after signing");
-        assertTrue(signedHeaders.containsKey("Digest"), "Digest header should be present for POST with body");
-        String signatureHeaderValue = signedHeaders.getFirst("Signature");
-        String actualKeyId = HttpSignature.extractKeyId(signatureHeaderValue);
-        assert actualKeyId != null;
-        assertFalse(actualKeyId.isEmpty());
+        HttpHeaders signedHeaders =
+                httpSignatureService.prepareSignedHeaders(HttpMethod.POST, TEST_ACCOUNT_ID, TEST_TARGET_URI,
+                                                          EXAMPLE_BODY).block();
+        assertNotNull(String.valueOf(signedHeaders), "Signed headers should not be null");
+        assert signedHeaders != null;
+        assertTrue(signedHeaders.containsKey("Digest"), "Generated headers must contain Digest for POST");
 
-        Flux<DataBuffer> bodyFluxForVerification = Flux.just(dataBufferFactory.wrap(EXAMPLE_BODY));
+        // mock Request for verification
+        Flux<org.springframework.core.io.buffer.DataBuffer> bodyFluxForVerification =
+                Flux.just(dataBufferFactory.wrap(EXAMPLE_BODY));
         MockServerHttpRequest mockServerRequest =
-                MockServerHttpRequest.method(signedRequest.method(), signedRequest.url()).headers(signedHeaders)
+                MockServerHttpRequest.post(TEST_TARGET_URI.toString()).headers(signedHeaders)
                         .body(bodyFluxForVerification);
         MockServerWebExchange mockExchange = MockServerWebExchange.from(mockServerRequest);
-        assert HARDCODED_PUBLIC_KEY != null;
-        doReturn(Mono.just(HARDCODED_PUBLIC_KEY)).when(httpSignatureService).fetchPublicKey(eq(actualKeyId));
 
-        Mono<Boolean> verificationResultMono = httpSignatureService.verifySignature(mockExchange);
-        StepVerifier.create(verificationResultMono).expectNext(true) // Expect successful verification
+        // mock PublicKeyResolver
+        String actualKeyId = HttpSignature.extractKeyId(signedHeaders.getFirst("Signature"));
+        assertNotNull(actualKeyId, "Could not extract keyId from generated signature");
+        assert HARDCODED_PUBLIC_KEY != null;
+        when(publicKeyResolver.resolve(eq(actualKeyId))).thenReturn(Mono.just(HARDCODED_PUBLIC_KEY));
+
+        // verify
+        Mono<Boolean> verificationResultMono = httpSignatureService.verifySignature(mockExchange, EXAMPLE_BODY);
+        StepVerifier.create(verificationResultMono).expectNext(true).verifyComplete();
+    }
+
+    @Test
+    void verifySignaturePOSTWithMismatchedDigestValueInHeaderShouldReturnFalse() {
+        PubKeyPair keyPair = new PubKeyPair(TEST_ACCOUNT_ID, HARDCODED_PUBLIC_KEY_PEM, HARDCODED_PRIVATE_KEY_PEM);
+        when(pubKeyPairRepository.findItemByAcct(TEST_ACCOUNT_ID)).thenReturn(Mono.just(keyPair));
+
+        // generate correct headers first
+        HttpHeaders correctlySignedHeaders =
+                httpSignatureService.prepareSignedHeaders(HttpMethod.POST, TEST_ACCOUNT_ID, TEST_TARGET_URI,
+                                                          EXAMPLE_BODY).block();
+        assertNotNull(String.valueOf(correctlySignedHeaders));
+
+        HttpHeaders tamperedHeaders = new HttpHeaders();
+        assert correctlySignedHeaders != null;
+        tamperedHeaders.addAll(correctlySignedHeaders);
+        tamperedHeaders.set("Digest", "SHA-256=100percentWrongDigestValue"); // Tamper the digest
+
+        Flux<org.springframework.core.io.buffer.DataBuffer> bodyFluxForVerification =
+                Flux.just(dataBufferFactory.wrap(EXAMPLE_BODY));
+        MockServerHttpRequest mockServerRequest =
+                MockServerHttpRequest.post(TEST_TARGET_URI.toString()).headers(tamperedHeaders)
+                        .body(bodyFluxForVerification);
+        MockServerWebExchange mockExchange = MockServerWebExchange.from(mockServerRequest);
+
+        String actualKeyId = HttpSignature.extractKeyId(tamperedHeaders.getFirst("Signature"));
+        assert HARDCODED_PUBLIC_KEY != null;
+        when(publicKeyResolver.resolve(eq(actualKeyId))).thenReturn(Mono.just(HARDCODED_PUBLIC_KEY));
+
+        Mono<Boolean> verificationResultMono = httpSignatureService.verifySignature(mockExchange, EXAMPLE_BODY);
+        StepVerifier.create(verificationResultMono)
+                .expectNext(false) // Expect verification to fail due to digest mismatch
                 .verifyComplete();
     }
 
+    // combined prepare headers and then verify signature
+    @Test
+    void prepareHeadersThenVerifySignature_POST_withBody_HappyPath() {
+        PubKeyPair keyPair = new PubKeyPair(TEST_ACCOUNT_ID, HARDCODED_PUBLIC_KEY_PEM, HARDCODED_PRIVATE_KEY_PEM);
+        when(pubKeyPairRepository.findItemByAcct(TEST_ACCOUNT_ID)).thenReturn(Mono.just(keyPair));
+
+        HttpHeaders generatedHeaders =
+                httpSignatureService.prepareSignedHeaders(HttpMethod.POST, TEST_ACCOUNT_ID, TEST_TARGET_URI,
+                                                          EXAMPLE_BODY).block();
+        assertNotNull(String.valueOf(generatedHeaders), "Generated headers should not be null");
+
+        Flux<byte[]> bodyFluxForVerification = Flux.just(EXAMPLE_BODY);
+        assert generatedHeaders != null;
+        MockServerHttpRequest mockServerRequest =
+                MockServerHttpRequest.post(TEST_TARGET_URI.toString()).headers(generatedHeaders)
+                        .body(String.valueOf(bodyFluxForVerification));
+        MockServerWebExchange mockExchange = MockServerWebExchange.from(mockServerRequest);
+
+        String actualKeyId = HttpSignature.extractKeyId(generatedHeaders.getFirst("Signature"));
+        assertNotNull(actualKeyId);
+        assert HARDCODED_PUBLIC_KEY != null;
+        when(publicKeyResolver.resolve(eq(actualKeyId))).thenReturn(Mono.just(HARDCODED_PUBLIC_KEY));
+
+        Mono<Boolean> verificationResultMono = httpSignatureService.verifySignature(mockExchange, EXAMPLE_BODY);
+        StepVerifier.create(verificationResultMono).expectNext(true).verifyComplete();
+    }
+
+    @Test
+    void prepareSignedHeadersPOSTWithNullBodyShouldSignDigestOfEmptyBody() {
+        PubKeyPair keyPair = new PubKeyPair(TEST_ACCOUNT_ID, HARDCODED_PUBLIC_KEY_PEM, HARDCODED_PRIVATE_KEY_PEM);
+        when(pubKeyPairRepository.findItemByAcct(TEST_ACCOUNT_ID)).thenReturn(Mono.just(keyPair));
+        URI targetUri = URI.create("https://target.example.com/outbox");
+
+        // calculate expected digest for an empty body
+        MessageDigest md = HttpSignature.newSHA256Digest();
+        byte[] expectedDigestBytes = md.digest(new byte[0]); // Digest of empty body
+        String expectedDigestHeaderValue = "sha-256=" + Base64.getEncoder().encodeToString(expectedDigestBytes);
+
+        Mono<HttpHeaders> headersMono =
+                httpSignatureService.prepareSignedHeaders(HttpMethod.POST, TEST_ACCOUNT_ID, targetUri,
+                                                          null); // Null body
+
+        StepVerifier.create(headersMono).expectNextMatches(headers -> {
+            assertTrue(headers.containsKey(HttpHeaders.DATE), "Date header should be present");
+            assertEquals("Host header mismatch", targetUri.getHost(), headers.getFirst(HttpHeaders.HOST));
+            assertTrue(headers.containsKey(HttpHeaders.ACCEPT), "Accept header should be present");
+
+            assertTrue(headers.containsKey("Digest"), "Digest header should be present for POST with null body");
+            assertEquals("Digest value for empty body mismatch", expectedDigestHeaderValue, headers.getFirst("Digest"));
+
+            assertTrue(headers.containsKey("Signature"), "Signature header should be present");
+            String sigHeader = headers.getFirst("Signature");
+            assertNotNull(sigHeader, "Signature header is null");
+
+            Map<String, String> sigFields = HttpSignature.extractFields(sigHeader);
+            String signedHeadersString = sigFields.get("headers");
+            assertNotNull(signedHeadersString, "headers field missing in Signature");
+            List<String> signedHeadersList = List.of(signedHeadersString.toLowerCase().split(" "));
+            // 'digest' should be signed even for a null body in a POST request
+            assertTrue(signedHeadersList.containsAll(List.of("(request-target)", "host", "date", "digest")),
+                       "Signed headers for POST with null body should include digest");
+            return true;
+        }).verifyComplete();
+    }
 }


### PR DESCRIPTION
HTTP Signature Verification:
- Added `HttpSignatureWebFilter` to enforce HTTP signature verification for protected POST endpoints (`/inbox`, `/users/{id}/inbox`). Requests without valid signatures are rejected with a `401 Unauthorized` status

Public Key fetching and caching 
- Added `RemotePublicKeyResolver` to fetch and cache public keys. Implemented positive and negative caching mechanisms using the **Caffeine library** to optimize key lookups 

ActivityPub Integration
- Added `ActivityPubService` to orchestrate the sending of AP activities

Dependency Updates
- Added the Caffeine library (`com.github.ben-manes.caffeine:caffeine:3.1.8`) for caching purposes

Refactoring
- using new `ActivityPubService` for sending signed activities. 
- updated `HttpSignatureService` for handling body directly through bytes[] 

Unit tests
- Updated Unit tests cases in `HttpSignatureServiceTest`
- Added Unit tests for `RemotePublicKeyResolverIntegrationTest` and `RemotePublicKeyResolverTest` 
- Added Unit test  for `HttpSignatureWebFilterTest`

