### PR TITLE
Add visibility enum value

### DIFF
--- a/server/src/main/java/edu/sjsu/moth/server/activitypub/service/OutboxService.java
+++ b/server/src/main/java/edu/sjsu/moth/server/activitypub/service/OutboxService.java
@@ -19,12 +19,10 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -64,7 +62,7 @@ public class OutboxService {
         String cc = "";
         String bcc = "";
 
-        VISIBILITY visibility = VisibilityService.fromString(Optional.ofNullable(status.visibility));
+        VISIBILITY visibility = VisibilityService.visibilityFromString(Optional.ofNullable(status.visibility));
         if (visibility == VISIBILITY.PRIVATE) {
             cc = actorUrl + "/followers";
             bcc = "";

--- a/server/src/main/java/edu/sjsu/moth/server/activitypub/service/OutboxService.java
+++ b/server/src/main/java/edu/sjsu/moth/server/activitypub/service/OutboxService.java
@@ -10,6 +10,8 @@ import edu.sjsu.moth.server.activitypub.message.CreateMessage;
 import edu.sjsu.moth.server.activitypub.message.NoteMessage;
 import edu.sjsu.moth.server.db.AccountRepository;
 import edu.sjsu.moth.server.db.OutboxRepository;
+import edu.sjsu.moth.server.service.VisibilityService;
+import edu.sjsu.moth.server.service.VisibilityService.VISIBILITY;
 import lombok.extern.apachecommons.CommonsLog;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
@@ -61,7 +63,8 @@ public class OutboxService {
         String cc = "";
         String bcc = "";
 
-        if (status.visibility != null && status.visibility.equals("private")) {
+        VISIBILITY visibility = VisibilityService.fromString(status.visibility);
+        if (visibility == VISIBILITY.PRIVATE) {
             cc = actorUrl + "/followers";
             bcc = "";
         } else {

--- a/server/src/main/java/edu/sjsu/moth/server/activitypub/service/OutboxService.java
+++ b/server/src/main/java/edu/sjsu/moth/server/activitypub/service/OutboxService.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.springframework.beans.support.PagedListHolder.DEFAULT_PAGE_SIZE;
 
@@ -63,7 +64,7 @@ public class OutboxService {
         String cc = "";
         String bcc = "";
 
-        VISIBILITY visibility = VisibilityService.fromString(status.visibility);
+        VISIBILITY visibility = VisibilityService.fromString(Optional.ofNullable(status.visibility));
         if (visibility == VISIBILITY.PRIVATE) {
             cc = actorUrl + "/followers";
             bcc = "";

--- a/server/src/main/java/edu/sjsu/moth/server/service/VisibilityService.java
+++ b/server/src/main/java/edu/sjsu/moth/server/service/VisibilityService.java
@@ -12,6 +12,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.security.Principal;
+import java.util.Optional;
 
 @Service
 @CommonsLog
@@ -31,14 +32,14 @@ public class VisibilityService {
         PUBLIC, UNLISTED, PRIVATE, DIRECT, UNDEFINED
     }
 
-    public static VISIBILITY fromString(String visibility) {
-        return switch (visibility) {
+    public static VISIBILITY fromString(Optional<String> visibility) {
+        return visibility.map(s -> switch (s) {
             case "public" -> VISIBILITY.PUBLIC;
             case "unlisted" -> VISIBILITY.UNLISTED;
             case "private" -> VISIBILITY.PRIVATE;
             case "direct" -> VISIBILITY.DIRECT;
             default -> VISIBILITY.UNDEFINED;
-        };
+        }).orElse(VISIBILITY.UNDEFINED);
     }
 
     public Flux<Status> publicTimelinesViewable(Status status) {

--- a/server/src/main/java/edu/sjsu/moth/server/service/VisibilityService.java
+++ b/server/src/main/java/edu/sjsu/moth/server/service/VisibilityService.java
@@ -1,7 +1,6 @@
 package edu.sjsu.moth.server.service;
 
 import edu.sjsu.moth.generated.Status;
-import edu.sjsu.moth.server.controller.MothController;
 import edu.sjsu.moth.server.db.FollowRepository;
 import edu.sjsu.moth.server.db.StatusMention;
 import lombok.extern.apachecommons.CommonsLog;
@@ -32,7 +31,7 @@ public class VisibilityService {
         PUBLIC, UNLISTED, PRIVATE, DIRECT, UNDEFINED
     }
 
-    public static VISIBILITY fromString(Optional<String> visibility) {
+    public static VISIBILITY visibilityFromString(Optional<String> visibility) {
         return visibility.map(s -> switch (s) {
             case "public" -> VISIBILITY.PUBLIC;
             case "unlisted" -> VISIBILITY.UNLISTED;

--- a/server/src/main/java/edu/sjsu/moth/server/service/VisibilityService.java
+++ b/server/src/main/java/edu/sjsu/moth/server/service/VisibilityService.java
@@ -27,6 +27,19 @@ public class VisibilityService {
     final String DIRECT_VISIBILITY = "direct";
     final String PRIVATE_VISIBILITY = "private";
 
+    public enum VISIBILITY {
+        PUBLIC, UNLISTED, PRIVATE, DIRECT, UNDEFINED
+    }
+
+    public static VISIBILITY fromString(String visibility) {
+        return switch (visibility) {
+            case "public" -> VISIBILITY.PUBLIC;
+            case "unlisted" -> VISIBILITY.UNLISTED;
+            case "private" -> VISIBILITY.PRIVATE;
+            case "direct" -> VISIBILITY.DIRECT;
+            default -> VISIBILITY.UNDEFINED;
+        };
+    }
 
     public Flux<Status> publicTimelinesViewable(Status status) {
         if (status.visibility.equals(PUBLIC_VISIBILITY)) return Flux.just(status);


### PR DESCRIPTION
- Currently, we are comparing the visibility by string value, and this is error prone and required hardcoded value. This PR introduce the Visibility Enum to facilitate the Visibility comparision in the future.
- Change includes:
- [x] added a Visibility enum value and a function to convert the Visibility status into Enum. 