### PR TITLE
Sorting the posts on homefeed

### DIFF
--- a/server/src/main/java/edu/sjsu/moth/server/service/StatusService.java
+++ b/server/src/main/java/edu/sjsu/moth/server/service/StatusService.java
@@ -45,6 +45,7 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 import java.security.Principal;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -200,13 +201,34 @@ public class StatusService {
         var qStatus = QStatus.status;
         var predicate = qStatus.content.isNotNull();
         predicate = addRangeQueries(predicate, max_id, since_id, max_id);
-        var external = externalStatusRepository.findAll(predicate, Sort.by(Sort.Direction.DESC, "id"))
+        Mono<List<ExternalStatus>> external = externalStatusRepository.findAll(predicate, Sort.by(Sort.Direction.DESC, "id"))
                 .flatMap(statuses -> visibilityService.homefeedViewable(user, statuses)).take(limit);
-        var internal = statusRepository.findAll(predicate, Sort.by(Sort.Direction.DESC, "id"))
+        Mono<List<Status>> internal = statusRepository.findAll(predicate, Sort.by(Sort.Direction.DESC, "id"))
                 .flatMap(statuses -> visibilityService.homefeedViewable(user, statuses)).take(limit);
 
-        //TODO: we may want to merge sort them, unsure if merge does that
-        return Flux.merge(external, internal).collectList();
+        return Mono.zip(external, internal)
+                .map(tuple -> {
+                    List<Status> merged = mergeByCreatedAtDesc(tuple.getT1(), tuple.getT2());
+                    return merged.stream().limit(limit).toList();
+                });
+    }
+
+    private List<Status> mergeByCreatedAtDesc(List<ExternalStatus> externalStatus, List<Status> internalStatus) {
+        List<Status> merged = new ArrayList<>(externalStatus.size() + internalStatus.size());
+        int i = 0, j = 0;
+
+        while (i < externalStatus.size() && j < internalStatus.size()) {
+            Instant externalCreatedAt = Instant.parse(externalStatus.get(i).createdAt);
+            Instant internalCreatedAt = Instant.parse(internalStatus.get(j).createdAt);
+            if (externalCreatedAt.isAfter(internalCreatedAt)) {
+                merged.add(externalStatus.get(i++));
+            } else {
+                merged.add(internalStatus.get(j++));
+            }
+        }
+        while (i < externalStatus.size()) merged.add(externalStatus.get(i++));
+        while (j < internalStatus.size()) merged.add(internalStatus.get(j++));
+        return merged;
     }
 
     public Mono<List<Status>> getPublicTimeline(Principal user, String max_id, String since_id, String min_id,


### PR DESCRIPTION
This PR introduces sorting the posts from both the same instance and people from a different instance. Sorting them based on the createdAt date. 