### PR TITLE
Displaying Federated Posts on Homefeed

### DIFF
--- a/server/src/main/java/edu/sjsu/moth/server/service/StatusService.java
+++ b/server/src/main/java/edu/sjsu/moth/server/service/StatusService.java
@@ -189,7 +189,7 @@ public class StatusService {
                 externalStatusRepository.findAll(predicate, Sort.by(Sort.Direction.DESC, "id")).take(limit)
                         .collectList();
         Mono<List<Status>> internal = statusRepository.findAll(predicate, Sort.by(Sort.Direction.DESC, "id"))
-                .flatMap(status -> visibilityService.publicTimelinesViewable(status)).take(limit).collectList();
+                .flatMap(status -> visibilityService.homefeedViewable(user, status)).take(limit).collectList();
 
         return Mono.zip(external, internal).map(tuple -> {
             List<Status> merged = mergeByCreatedAtDesc(tuple.getT1(), tuple.getT2());


### PR DESCRIPTION
This PR implements the functionality to display federated posts on the home feed. It builds upon the previously completed follow feature, which enabled following federated users in both directions (local to federated and vice versa).

**Key Updates:**
- Home feed now includes posts from federated users.
- Federated posts are delivered to all followers, ensuring they appear in their respective home feeds.
- Completes the end-to-end flow for federated user interactions: Follow → Post → Deliver → Display.
- Now the author will be able to see their posts on the home feed.

The below image displays both the internal and federated posts on the user home feed.
<img width="335" height="696" alt="Screenshot 2025-09-08 at 1 11 59 PM" src="https://github.com/user-attachments/assets/74419270-cf2f-49da-bf22-00e73980c062" />
