### PR TITLE
Federated Search Refactor: WebFinger Remote User Discovery & Outbox Ingestion

### DIFF
--- a/server/src/main/java/edu/sjsu/moth/server/activitypub/service/WebfingerService.java
+++ b/server/src/main/java/edu/sjsu/moth/server/activitypub/service/WebfingerService.java
@@ -1,0 +1,35 @@
+package edu.sjsu.moth.server.activitypub.service;
+
+import edu.sjsu.moth.util.WebFingerUtils;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.Mono;
+
+@Service
+public class WebfingerService {
+
+    private final WebClient webClient;
+
+    public WebfingerService(WebClient.Builder webClientBuilder) {
+        this.webClient = webClientBuilder.build();
+    }
+
+    public Mono<String> discoverProfileUrl(String userHandle) {
+        String[] parts = userHandle.split("@");
+        if (parts.length != 2) {
+            return Mono.error(new IllegalArgumentException("Invalid user handle: " + userHandle));
+        }
+        String domain = parts[1];
+        String url = "https://" + domain + "/.well-known/webfinger?resource=acct:" + userHandle;
+
+        return webClient.get().uri(url).retrieve().bodyToMono(WebFingerUtils.WebFinger.class).flatMap(webFinger -> {
+            for (WebFingerUtils.FingerLink link : webFinger.links()) {
+                if (WebFingerUtils.RelType.SELF.equals(link.rel()) && "application/activity+json".equals(link.type())) {
+                    return Mono.just(link.href());
+                }
+            }
+            return Mono.empty();
+        }).onErrorResume(WebClientResponseException.NotFound.class, e -> Mono.empty());
+    }
+}

--- a/server/src/main/java/edu/sjsu/moth/server/controller/SearchController.java
+++ b/server/src/main/java/edu/sjsu/moth/server/controller/SearchController.java
@@ -1,23 +1,17 @@
 package edu.sjsu.moth.server.controller;
 
 import edu.sjsu.moth.generated.SearchResult;
-import edu.sjsu.moth.server.db.Account;
-import edu.sjsu.moth.server.db.AccountRepository;
-import edu.sjsu.moth.server.db.ExternalActorRepository;
+import edu.sjsu.moth.generated.Status;
 import edu.sjsu.moth.server.service.AccountService;
+import edu.sjsu.moth.server.service.ActorService;
 import edu.sjsu.moth.server.service.StatusService;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.reactive.function.client.WebClient;
-import org.springframework.web.reactive.function.client.WebClientException;
 import reactor.core.publisher.Mono;
 
 import java.security.Principal;
-import java.util.List;
-import java.util.Optional;
 
 @RestController
 public class SearchController {
@@ -29,11 +23,7 @@ public class SearchController {
     AccountService accountService;
 
     @Autowired
-    AccountRepository accountRepository;
-
-    @Autowired
-    public SearchController(WebClient.Builder webBuilder) {
-    }
+    ActorService actorService;
 
     @GetMapping("api/v2/search")
     // DOCS FOR SPECS --> https://docs.joinmastodon.org/methods/search/
@@ -53,61 +43,31 @@ public class SearchController {
         if (query.length() < 3) {
             return Mono.just(result);
         }
-        // search results limiter defaulter
         if (limit == null || limit == 0 || limit >= 41) {
             limit = 20;
         }
-        //// this is meant for if someone does @user@someInstance.com, splitQuery[1] will be someInstance
+
         if (query.contains("@")) {
-            if (query.startsWith("@")) // truncate leading @ if its above, transform into user@someInstance.com
-                query = query.substring(1);
-            String[] splitQuery = query.split("@", 2); // split into 2 parts, split at @ char
-            if (splitQuery.length == 2 && !splitQuery[0].isEmpty() && !splitQuery[1].isEmpty()) {
-                String domain = splitQuery[1].trim();
-
-                // Optional: Validate domain (basic check)
-                if (!domain.matches("^[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$")) {
-                    return Mono.empty();
-                }
-
-                String baseUrl = "https://" + domain + "/api/v2/search";
-                Integer finalLimit = limit; // necessary as local var ref from lambda must be final
-                return WebClient.builder().baseUrl(baseUrl).build().get()
-                        .uri(uriBuilder -> uriBuilder.queryParam("q", splitQuery[0]).queryParam("limit", finalLimit)
-                                .queryParamIfPresent("type", Optional.ofNullable(type)).build())
-                        .accept(MediaType.APPLICATION_JSON).retrieve().bodyToMono(SearchResult.class)
-                        .flatMap(searchResult -> {
-                            if (searchResult.accounts == null || searchResult.accounts.isEmpty()) {
-                                return Mono.just(searchResult);
-                            }
-                            // Filter out local users and normalize remote accts
-                            List<Account> remoteAccounts = searchResult.accounts.stream().filter(account -> {
-                                // If the URL does not point to your own domain, it's remote
-                                return account.url != null && !account.url.contains(MothController.HOSTNAME);
-                            }).peek(account -> {
-                                // If acct does not contain "@", normalize it with the remote domain
-                                if (account.acct != null && !account.acct.contains("@")) {
-                                    String remoteDomain = account.url.split("/")[2]; // e.g., mastodon.social
-                                    account.acct = account.acct + "@" + remoteDomain;
-                                    account.id = account.acct;
-                                }
-                            }).toList();
-
-                            if (remoteAccounts.isEmpty()) {
-                                return Mono.just(searchResult);
-                            }
-
-                            return accountRepository.saveAll(remoteAccounts).then(Mono.just(searchResult));
-                        }).onErrorResume(WebClientException.class, e -> {
-                            System.err.println("Error: " + e.getMessage());
-                            return Mono.empty();
-                        });
-
-            }
+            String userHandle = query.startsWith("@") ? query.substring(1) : query;
+            return actorService.resolveRemoteAccount(userHandle).map(account -> {
+                result.accounts.add(account);
+                Status statuses = Mono.just(new Status()).block();
+                result.statuses.add(statuses);
+                return result;
+            }).switchIfEmpty(Mono.just(new SearchResult())).onErrorResume(e -> Mono.just(new SearchResult()));
         } else {
             // normal search (of local instance)
-            switch (type) {
-                case "": {
+            String searchType = type == null ? "" : type;
+            switch (searchType) {
+                case "accounts":
+                    return accountService.filterAccountSearch(query, user, following, max_id, min_id, limit, offset,
+                                                              result);
+                case "statuses":
+                    return statusService.filterStatusSearch(query, user, account_id, max_id, min_id, limit, offset,
+                                                            result);
+                case "hashtags":
+                    return Mono.just(new SearchResult()); // Not implemented
+                default:
                     return Mono.zip(
                             accountService.filterAccountSearch(query, user, following, max_id, min_id, limit, offset,
                                                                result),
@@ -117,23 +77,7 @@ public class SearchController {
                         result.statuses = t.getT2().statuses;
                         return result;
                     });
-                }
-                case "accounts": {
-                    return accountService.filterAccountSearch(query, user, following, max_id, min_id, limit, offset,
-                                                              result);
-                }
-                case "statuses": {
-                    return statusService.filterStatusSearch(query, user, account_id, max_id, min_id, limit, offset,
-                                                            result);
-                }
-                case "hashtags": {
-                    // incomplete; complete when hashtags are implemented
-                    // check RequestParams: exclude_unreviewed, max_id, min_id, offset
-                    return null;
-                }
             }
-
         }
-        return Mono.empty();
     }
 }

--- a/server/src/main/java/edu/sjsu/moth/server/controller/StatusController.java
+++ b/server/src/main/java/edu/sjsu/moth/server/controller/StatusController.java
@@ -188,9 +188,16 @@ public class StatusController {
             /* Boolean. Filter for pinned statuses only. Defaults to false, which includes all statuses. Pinned
             statuses do not receive special priority in the order of the returned results. */ Boolean pinned,
             /* String. Filter for statuses using a specific hashtag */ String tagged) {
-        return accountService.getAccountById(id).flatMap(
-                        acct -> statusService.getStatusesForId(user, acct.username, max_id, since_id, min_id, only_media,
-                                                               exclude_replies, exclude_reblogs, pinned, tagged, limit))
+        // If the id already looks like a remote handle, go through the remote path
+        if (id.contains("@")) {
+            return statusService.getStatusesForId(user, id, max_id, since_id, min_id, only_media, exclude_replies,
+                                                  exclude_reblogs, pinned, tagged, limit).map(ResponseEntity::ok);
+        }
+
+        return accountService.getAccountById(id)
+                .flatMap(acct -> statusService.getStatusesForId(user, acct.username, max_id, since_id, min_id,
+                                                                only_media, exclude_replies, exclude_reblogs, pinned,
+                                                                tagged, limit))
                 .map(ResponseEntity::ok);
     }
 

--- a/server/src/main/java/edu/sjsu/moth/server/db/ExternalStatusRepository.java
+++ b/server/src/main/java/edu/sjsu/moth/server/db/ExternalStatusRepository.java
@@ -2,6 +2,9 @@ package edu.sjsu.moth.server.db;
 
 import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
 import org.springframework.data.querydsl.ReactiveQuerydslPredicateExecutor;
+import reactor.core.publisher.Flux;
 
 public interface ExternalStatusRepository
-        extends ReactiveMongoRepository<ExternalStatus, String>, ReactiveQuerydslPredicateExecutor<ExternalStatus> {}
+        extends ReactiveMongoRepository<ExternalStatus, String>, ReactiveQuerydslPredicateExecutor<ExternalStatus> {
+    Flux<ExternalStatus> findAllByAccount_AcctOrderByCreatedAtDesc(String acct);
+}

--- a/server/src/main/java/edu/sjsu/moth/server/service/ActorService.java
+++ b/server/src/main/java/edu/sjsu/moth/server/service/ActorService.java
@@ -32,12 +32,14 @@ public class ActorService {
         return externalActorRepository != null ? externalActorRepository.findItemById(actor) : Mono.empty();
     }
 
+    public Mono<Actor> fetchAndSaveActorById(String actorId) {
+        return webClient.get().uri(actorId).accept(MediaType.parseMediaType("application/activity+json")).retrieve()
+                .bodyToMono(Actor.class).flatMap(this::save);
+    }
+
     public Mono<Account> resolveRemoteAccount(String userHandle) {
-        return webfingerService.discoverProfileUrl(userHandle)
-                .flatMap(profileUrl -> webClient.get().uri(profileUrl)
-                        .accept(MediaType.parseMediaType("application/activity+json"))
-                        .retrieve()
-                        .bodyToMono(Actor.class))
+        return webfingerService.discoverProfileUrl(userHandle).flatMap(profileUrl -> webClient.get().uri(profileUrl)
+                        .accept(MediaType.parseMediaType("application/activity+json")).retrieve().bodyToMono(Actor.class))
                 .flatMap(actor -> save(actor).then(InboxController.convertToAccount(actor)));
     }
 }

--- a/server/src/main/java/edu/sjsu/moth/server/service/RemoteOutboxFetcher.java
+++ b/server/src/main/java/edu/sjsu/moth/server/service/RemoteOutboxFetcher.java
@@ -1,0 +1,54 @@
+package edu.sjsu.moth.server.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * Fetches the first page of a remote actor's outbox and returns Create activities.
+ */
+@Service
+public class RemoteOutboxFetcher {
+
+    private final WebClient webClient;
+
+    public RemoteOutboxFetcher(WebClient.Builder builder) {
+        this.webClient = builder.defaultHeader(HttpHeaders.ACCEPT, "application/activity+json").build();
+    }
+
+    public Flux<JsonNode> fetchCreateActivities(String outboxUrl, int limit) {
+        return fetch(outboxUrl).flatMapMany(root -> {
+            String type = text(root.path("type"));
+            if ("OrderedCollection".equals(type)) {
+                String first = text(root.path("first"));
+                if (first == null || first.isBlank()) {
+                    return Flux.empty();
+                }
+                return fetch(first).flatMapMany(this::itemsFromPage);
+            } else {
+                return itemsFromPage(root);
+            }
+        }).filter(this::isCreateNote).take(limit);
+    }
+
+    private Mono<JsonNode> fetch(String url) {
+        return webClient.get().uri(url).retrieve().bodyToMono(JsonNode.class);
+    }
+
+    private Flux<JsonNode> itemsFromPage(JsonNode page) {
+        JsonNode items = page.path("orderedItems");
+        if (items == null || !items.isArray()) return Flux.empty();
+        return Flux.fromIterable(items);
+    }
+
+    private boolean isCreateNote(JsonNode item) {
+        return "Create".equals(text(item.path("type"))) && "Note".equals(text(item.path("object").path("type")));
+    }
+
+    private String text(JsonNode node) {
+        return node != null && node.isTextual() ? node.asText() : null;
+    }
+}

--- a/server/src/main/java/edu/sjsu/moth/server/service/RemoteStatusIngestService.java
+++ b/server/src/main/java/edu/sjsu/moth/server/service/RemoteStatusIngestService.java
@@ -1,0 +1,60 @@
+package edu.sjsu.moth.server.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import edu.sjsu.moth.generated.Actor;
+import edu.sjsu.moth.server.db.ExternalStatus;
+import edu.sjsu.moth.server.db.ExternalStatusRepository;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+@Service
+public class RemoteStatusIngestService {
+
+    private final ExternalStatusRepository externalStatusRepository;
+
+    public RemoteStatusIngestService(ExternalStatusRepository repo) {
+        this.externalStatusRepository = repo;
+    }
+
+    public Mono<List<ExternalStatus>> ingestCreateNotes(Flux<JsonNode> createActivities, Actor actor,
+                                                        AccountSnapshotProvider accountSnapshotProvider) {
+        return accountSnapshotProvider.getAccountSnapshot(actor).flatMap(account -> createActivities.flatMap(item -> {
+            JsonNode obj = item.path("object");
+            String id = text(obj.path("id"));
+            if (id == null || id.isBlank()) return Mono.empty();
+
+            return externalStatusRepository.findById(id).switchIfEmpty(mapNoteToExternal(obj, item, account))
+                    .flatMap(existingOrNew -> Mono.just(existingOrNew));
+        }).collectList());
+    }
+
+    private Mono<ExternalStatus> mapNoteToExternal(JsonNode note, JsonNode create,
+                                                   edu.sjsu.moth.server.db.Account acc) {
+        String id = text(note.path("id"));
+        String published = text(create.path("published"));
+        boolean sensitive = note.path("sensitive").asBoolean(false);
+        String content = text(note.path("content"));
+        String language = null;
+        JsonNode contentMap = note.path("contentMap");
+        if (contentMap != null && contentMap.fieldNames().hasNext()) {
+            language = contentMap.fieldNames().next();
+        }
+
+        ExternalStatus status =
+                new ExternalStatus(id, published, null, null, sensitive, "", "public", language, id, id, 0, 0, 0, false,
+                                   false, false, false, content, null, null, acc, List.of(), List.of(), List.of(),
+                                   List.of(), null, null, content, published);
+        return externalStatusRepository.save(status);
+    }
+
+    private String text(JsonNode node) {
+        return node != null && node.isTextual() ? node.asText() : null;
+    }
+
+    public interface AccountSnapshotProvider {
+        Mono<edu.sjsu.moth.server.db.Account> getAccountSnapshot(Actor actor);
+    }
+}

--- a/server/src/test/java/edu/sjsu/moth/server/activitypub/service/WebfingerServiceTests.java
+++ b/server/src/test/java/edu/sjsu/moth/server/activitypub/service/WebfingerServiceTests.java
@@ -1,0 +1,28 @@
+package edu.sjsu.moth.server.activitypub.service;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+public class WebfingerServiceTests {
+
+    @Test
+    public void testDiscoverProfileUrl() {
+        WebfingerService webfingerService = new WebfingerService(WebClient.builder());
+        String userHandle = "divyamonmastodon@mastodon.social";
+        Mono<String> profileUrlMono = webfingerService.discoverProfileUrl(userHandle);
+
+        StepVerifier.create(profileUrlMono).expectNext("https://mastodon.social/users/divyamonmastodon")
+                .verifyComplete();
+    }
+
+    @Test
+    public void testDiscoverProfileUrlNotFound() {
+        WebfingerService webfingerService = new WebfingerService(WebClient.builder());
+        String userHandle = "nonexistentuser@mastodon.social";
+        Mono<String> profileUrlMono = webfingerService.discoverProfileUrl(userHandle);
+
+        StepVerifier.create(profileUrlMono).verifyComplete();
+    }
+}

--- a/server/src/test/java/edu/sjsu/moth/server/service/ActorServiceTests.java
+++ b/server/src/test/java/edu/sjsu/moth/server/service/ActorServiceTests.java
@@ -1,0 +1,40 @@
+package edu.sjsu.moth.server.service;
+
+import edu.sjsu.moth.server.activitypub.service.WebfingerService;
+import edu.sjsu.moth.server.db.Account;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+public class ActorServiceTests {
+
+    private ActorService actorService;
+
+    @BeforeEach
+    public void setUp() {
+        WebClient.Builder webClientBuilder = WebClient.builder();
+        WebfingerService webfingerService = new WebfingerService(webClientBuilder);
+        actorService = new ActorService(null, webfingerService, webClientBuilder);
+    }
+
+    @Test
+    public void resolveRemoteAccount_minimal() {
+        Mono<Account> mono = actorService.resolveRemoteAccount("gargron@mastodon.social")
+                .doOnNext(a -> System.out.println("username=" + a.username + ", acct=" + a.acct + ", url=" + a.url));
+
+        StepVerifier.create(mono).assertNext(a -> {
+            // username is preferredUsername
+            assert a.username != null && !a.username.isBlank();
+            assert a.username.equalsIgnoreCase("gargron");
+
+            // acct is FULL handle
+            assert a.acct != null && !a.acct.isBlank();
+            assert a.acct.equalsIgnoreCase("gargron@mastodon.social");
+
+            // sanity: URL should be from valid server! -> mastodon.social
+            assert a.url != null && a.url.contains("mastodon.social");
+        }).verifyComplete();
+    }
+}

--- a/server/src/test/java/edu/sjsu/moth/server/service/RemoteStatusIngestServiceTest.java
+++ b/server/src/test/java/edu/sjsu/moth/server/service/RemoteStatusIngestServiceTest.java
@@ -1,0 +1,66 @@
+package edu.sjsu.moth.server.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import edu.sjsu.moth.generated.Actor;
+import edu.sjsu.moth.server.db.Account;
+import edu.sjsu.moth.server.db.ExternalStatus;
+import edu.sjsu.moth.server.db.ExternalStatusRepository;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+public class RemoteStatusIngestServiceTest {
+
+    @Test
+    public void testIngestSingleCreateNote() throws Exception {
+        ExternalStatusRepository repo = Mockito.mock(ExternalStatusRepository.class);
+        RemoteStatusIngestService svc = new RemoteStatusIngestService(repo);
+
+        ObjectMapper om = new ObjectMapper();
+        // Build a minimal Create(Note) activity
+        ObjectNode note = om.createObjectNode();
+        note.put("type", "Note");
+        note.put("id", "https://remote.example/users/alice/statuses/1");
+        note.put("content", "<p>Hello</p>");
+
+        ObjectNode create = om.createObjectNode();
+        create.put("type", "Create");
+        create.put("published", "2025-01-01T00:00:00Z");
+        create.set("object", note);
+
+        Flux<JsonNode> activities = Flux.just((JsonNode) create);
+
+        Actor actor = new Actor();
+        actor.id = "https://remote.example/users/alice";
+        actor.preferredUsername = "alice";
+        actor.url = "https://remote.example/@alice";
+
+        RemoteStatusIngestService.AccountSnapshotProvider provider = a -> {
+            Account acc = new Account();
+            acc.id = "alice@remote.example";
+            acc.username = "alice";
+            acc.acct = "alice@remote.example";
+            acc.url = "https://remote.example/@alice";
+            return Mono.just(acc);
+        };
+
+        when(repo.findById(Mockito.anyString())).thenReturn(Mono.empty());
+        when(repo.save(any())).thenAnswer(inv -> Mono.just(inv.getArgument(0)));
+
+        List<ExternalStatus> saved = svc.ingestCreateNotes(activities, actor, provider).block();
+        assertNotNull(saved);
+        assertEquals(1, saved.size());
+        assertEquals("https://remote.example/users/alice/statuses/1", saved.get(0).id);
+        assertEquals("<p>Hello</p>", saved.get(0).content);
+    }
+}

--- a/server/src/test/java/edu/sjsu/moth/server/service/StatusServiceExternalIT.java
+++ b/server/src/test/java/edu/sjsu/moth/server/service/StatusServiceExternalIT.java
@@ -1,0 +1,95 @@
+package edu.sjsu.moth.server.service;
+
+import de.flapdoodle.embed.mongo.config.Net;
+import de.flapdoodle.embed.mongo.distribution.Version;
+import de.flapdoodle.embed.mongo.transitions.Mongod;
+import de.flapdoodle.embed.mongo.transitions.RunningMongodProcess;
+import de.flapdoodle.embed.process.io.ProcessOutput;
+import de.flapdoodle.reverse.TransitionWalker;
+import de.flapdoodle.reverse.transitions.Start;
+import edu.sjsu.moth.server.MothServerMain;
+import edu.sjsu.moth.server.db.ExternalStatusRepository;
+import edu.sjsu.moth.server.util.MothConfiguration;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.ComponentScan;
+
+import java.io.File;
+import java.security.Principal;
+import java.time.Duration;
+
+@EnabledIfSystemProperty(named = "externalTests", matches = "true")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureDataMongo
+@AutoConfigureWebTestClient
+@ComponentScan(basePackageClasses = MothServerMain.class)
+public class StatusServiceExternalIT {
+
+    static private final int RAND_MONGO_PORT = 27017 + new java.util.Random().nextInt(17, 37);
+    static private TransitionWalker.ReachedState<RunningMongodProcess> eMongod;
+
+    static {
+        try {
+            var fullname = edu.sjsu.moth.IntegrationTest.class.getResource("/test.cfg").getFile();
+            System.out.println(new MothConfiguration(new File(fullname)).properties);
+        } catch (Exception e) {
+            System.err.println(e.getMessage());
+            System.exit(2);
+        }
+    }
+
+    @Autowired
+    ActorService actorService;
+    @Autowired
+    StatusService statusService;
+    @Autowired
+    ExternalStatusRepository externalStatusRepository;
+
+    @BeforeAll
+    static void setup() {
+        String useLocalMongo = System.getProperty("useLocalMongo", "false");
+        if ("true".equalsIgnoreCase(useLocalMongo)) {
+            System.setProperty("spring.data.mongodb.port", "27017");
+            String dbName = System.getProperty("mongoDbName", "moth_test");
+            System.setProperty("spring.data.mongodb.database", dbName);
+            System.out.println("Using local MongoDB at 27017, database=" + dbName);
+            return;
+        }
+        eMongod = Mongod.builder().processOutput(Start.to(ProcessOutput.class).initializedWith(ProcessOutput.silent()))
+                .net(Start.to(Net.class).initializedWith(Net.defaults().withPort(RAND_MONGO_PORT))).build()
+                .start(Version.Main.V6_0);
+        System.setProperty("spring.data.mongodb.port", Integer.toString(RAND_MONGO_PORT));
+    }
+
+    @AfterAll
+    static void clean() {
+        if (eMongod != null) eMongod.close();
+    }
+
+    @Test
+    public void fetchGargronOutboxAndIngest() {
+        // 1) Resolve and cache the actor
+        var acct = "Alice@mastodon.social";
+        actorService.resolveRemoteAccount(acct).block(Duration.ofSeconds(30));
+
+        // 2) Trigger remote ingest via getStatusesForId
+        Principal p = () -> "test-user";
+        var list = statusService.getStatusesForId(p, acct, null, null, null, false, false, false, null, null, 5)
+                .block(Duration.ofSeconds(60));
+
+        Assertions.assertNotNull(list);
+
+        // 3) Verify something exists for this actor in ExternalStatusRepository
+        var one = externalStatusRepository.findAllByAccount_AcctOrderByCreatedAtDesc(acct).take(1).collectList()
+                .block(Duration.ofSeconds(30));
+        Assertions.assertNotNull(one);
+        Assertions.assertFalse(one.isEmpty(), "Expected at least one ingested status for " + acct);
+    }
+}


### PR DESCRIPTION
### Summary
This PR refactors and extends the search, adds federation support for remote users via WebFinger, and ingests their posts (**limited to the first page**) by fetching remote ActivityPub outboxes. It persists only Actor entities and ingests remote Status to the ExternalStatusRepository from outbox items.

## Key changes
- Replaced client search API with WebfingerService for resolving remote actor
- Added ActorService to fetch and cache remote actors
- Remote search now saves remote actors to the ExternalActorRepository (not local accounts)
- Created RemoteOutboxFetcher to retrieve the outbox from remote ActivityPub actors
- Added RemoteStatusIngestService to map and persist remote statuses as ExternalStatus documents
- Updated StatusService to integrate remote status ingestion and retrieval
- Updated ExternalStatusRepository to support querying statuses by remote account

## How to Test
Search for a remote account @user@remote.instance
1. Verify an Actor is created/updated locally
2. Trigger outbox fetch for that actor
3. Verify remote posts appear in ExternalStatus

## Testing
1. Added new and updated existing tests for Webfinger discovery, remote account resolution, and remote status ingestion
2. Improved integration tests for search and remote user handling